### PR TITLE
My First Pull Request

### DIFF
--- a/lib/surveyor/engine.rb
+++ b/lib/surveyor/engine.rb
@@ -3,9 +3,8 @@ require 'surveyor'
 
 module Surveyor
   class Engine < Rails::Engine
-    engine_name :surveyor
     rake_tasks do
-      load "lib/tasks/surveyor_tasks.rake"
+      load "tasks/surveyor_tasks.rake"
     end
   end
 end


### PR DESCRIPTION
Changing the engine.rb to work with Rails 3
The reference point for the load of rake tasks is the gem's lib directory. Rake tasks are in tasks, hence the change. 

Removed engine_name as it seems to be deprecated in Rails3 released version.
