### PR TITLE
Fixes custom classes not appearing on text answer fields (Bug #113)

### DIFF
--- a/app/helpers/surveyor_helper.rb
+++ b/app/helpers/surveyor_helper.rb
@@ -63,6 +63,12 @@ module SurveyorHelper
     else type_sym
     end
   end
+  def generate_pick_none_input_html(response_class, default_value, css_class)
+    html = {}
+    html[:class] = css_class unless css_class.blank?
+    html[:value] = default_value if response_class.blank?
+    html
+  end
   
   # Responses
   def response_for(response_set, question, answer = nil, response_group = nil)

--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -14,6 +14,6 @@
   - when "none"
     - if %w(date datetime time float integer string text).include? a.response_class
       = ff.quiet_input :answer_id, :input_html => {:class => a.css_class, :value => a.id}
-      = ff.input rc_to_attr(a.response_class), :as => rc_to_as(a.response_class), :label => a.split_or_hidden_text(:pre).blank? ? false : a.split_or_hidden_text(:pre), :hint => a.split_or_hidden_text(:post), :input_html => (r.as(a.response_class).blank? ? {:value => a.default_value} : {})
+      = ff.input rc_to_attr(a.response_class), :as => rc_to_as(a.response_class), :label => a.split_or_hidden_text(:pre).blank? ? false : a.split_or_hidden_text(:pre), :hint => a.split_or_hidden_text(:post), :input_html => generate_pick_none_input_html(r.as(a.response_class), a.default_value, a.css_class)
     - else
       = a.text

--- a/features/step_definitions/surveyor_steps.rb
+++ b/features/step_definitions/surveyor_steps.rb
@@ -32,3 +32,7 @@ Then /^question "([^"]*)" should have a dependency with rule "([^"]*)"$/ do |qr,
   q.dependency.should_not be_nil
   q.dependency.rule.should == rule
 end
+
+Then /^the element "([^"]*)" should have the class "([^"]*)"$/ do |selector, css_class|
+  response.should have_selector(selector, :class => css_class)
+end

--- a/features/surveyor.feature
+++ b/features/surveyor.feature
@@ -80,3 +80,22 @@ Feature: Survey creation
       end
     """
     Then question "1" should have correct answer "oink"
+    
+  Scenario: Custom css class
+    Given the survey
+    """
+      survey "Movies" do
+        section "First" do
+          q "What is your favorite movie?"
+          a :string, :custom_class => "my_custom_class"
+          q "What is your favorite state?"
+          a :string
+        end
+      end
+    """
+    When I start the "Movies" survey
+    Then the element "input[type='text']:first" should have the class "my_custom_class"
+    # Then the element "input[type='text']:last" should not contain the class attribute
+    
+    
+    


### PR DESCRIPTION
When using the custom_class attribute on an answer (type string), the custom class will not be added to the displayed input field. Instead the CSS class will appear on the hidden field.
