### PR TITLE
The styles for grid radio inputs and grid check box inputs are slightly different 

### DIFF
--- a/generators/surveyor/templates/assets/stylesheets/sass/surveyor.sass
+++ b/generators/surveyor/templates/assets/stylesheets/sass/surveyor.sass
@@ -61,6 +61,10 @@ body
       :visibility hidden
       input
         :visibility visible
+    li.surveyor_check_boxes label
+      :visibility hidden
+      input
+        :visibility visible
   fieldset.g_repeater
     ol fieldset
       :display inline


### PR DESCRIPTION
When you create a grid with :pick_one, the individual labels for each radio button are hidden.  When you create a grid with :pick_any, the individual labels for each check box are not hidden.
