### PR TITLE
Conditional question group causes exception to be thrown

### DIFF
--- a/generators/surveyor/templates/surveys/kitchen_sink_survey.rb
+++ b/generators/surveyor/templates/surveys/kitchen_sink_survey.rb
@@ -211,8 +211,14 @@ survey "Kitchen Sink survey" do
     a "knife", :string
     a :other, :string
     
+    q_car "Do you own a car?", :pick => :one
+    a_y "Yes"
+    a_n "No"
+    
     # Repeaters allow multiple responses to a question or set of questions
     repeater "Tell us about the cars you own" do
+      dependency :rule => "A"
+      condition_A :q_car, "==", :a_y
       q "Make", :pick => :one, :display_type => :dropdown
       a "Toyota"
       a "Ford"

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -103,6 +103,9 @@ module Surveyor
       def is_unanswered?(question)
         self.responses.detect{|r| r.question_id == question.id}.nil?
       end
+      def is_group_unanswered?(group)
+        group.questions.any?{|question| is_unanswered?(question)}
+      end
 
       # Returns the number of response groups (count of group responses enterted) for this question group
       def count_group_responses(questions)
@@ -110,7 +113,15 @@ module Surveyor
       end
 
       def unanswered_dependencies
-        dependencies.select{|d| d.is_met?(self) and self.is_unanswered?(d.question)}.map(&:question)
+        unanswered_question_dependencies + unanswered_question_group_dependencies
+      end
+      
+      def unanswered_question_dependencies
+        dependencies.select{|d| d.is_met?(self) and d.question and self.is_unanswered?(d.question)}.map(&:question)
+      end
+      
+      def unanswered_question_group_dependencies
+        dependencies.select{|d| d.is_met?(self) and d.question_group and self.is_group_unanswered?(d.question_group)}.map(&:question_group)
       end
 
       def all_dependencies(question_ids = nil)

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -138,7 +138,23 @@ describe ResponseSet, "with dependencies" do
   it "should list answered and unanswered dependencies to show inline (javascript turned on)" do
     @response_set.all_dependencies[:show].should == ["q_#{@what_flavor.id}", "q_#{@what_bakery.id}"]
   end
-  
+  it "should list group as dependency" do
+    # Question Group
+    crust_group = Factory(:question_group, :text => "Favorite Crusts")
+    
+    # Question
+    what_crust = Factory(:question, :text => "What is your favorite curst type?", :survey_section => @section)
+    crust_group.questions << what_crust
+
+    # Answers
+    what_crust.answers << Factory(:answer, :response_class => :string, :question_id => what_crust.id)
+    
+    # Dependency
+    crust_group_dep = Factory(:dependency, :rule => "C", :question_group_id => crust_group.id, :question => nil)
+    Factory(:dependency_condition, :rule_key => "C", :question_id => @do_you_like_pie.id, :operator => "==", :answer_id => @do_you_like_pie.answers.first.id, :dependency_id => crust_group_dep.id)
+    
+    @response_set.unanswered_dependencies.should == [@what_bakery, crust_group]
+  end
 end
 describe ResponseSet, "as a quiz" do
   before(:each) do


### PR DESCRIPTION
If you have a section that contains a conditional question group and the condition rule is true, when you navigate to the next section an exception will be thrown.  An survey which causes this exception is included below.

<pre>
survey "Example" do
  section "Car questions" do
    q_car "Do you own a car?", :pick => :one
    a_y "Yes"
    a_n "No"
    
    # Repeaters allow multiple responses to a question or set of questions
    repeater "Tell us about the cars you own" do
      dependency :rule => "A"
      condition_A :q_car, "==", :a_y
      q "Make", :pick => :one
      a "Toyota"
      a "Ford"
    end
  end
  section "Other question" do
    label "These questions are examples of the basic supported input types"
  end
end
</pre>
