### PR TITLE
Dropdowns inside of repeaters display as radio buttons

### DIFF
--- a/app/views/partials/_question.html.haml
+++ b/app/views/partials/_question.html.haml
@@ -5,7 +5,7 @@
   %span.help= q.help_text
   - case renderer
   - when :image, :label
-  - when :dropdown, :inline_dropdown, :slider
+  - when :dropdown, :inline_dropdown, :slider, :repeater_dropdown
     - r = response_for(@response_set, q, nil, rg)
     - i = response_idx
     - f.semantic_fields_for i, r do |ff|

--- a/features/step_definitions/surveyor_steps.rb
+++ b/features/step_definitions/surveyor_steps.rb
@@ -36,3 +36,13 @@ end
 Then /^the element "([^"]*)" should have the class "([^"]*)"$/ do |selector, css_class|
   response.should have_selector(selector, :class => css_class)
 end
+
+Then /^a dropdown should exist with the options "([^"]*)"$/ do |options_text|
+  response.should have_selector('select')
+  options = options_text.split(',').collect(&:strip)
+  within "select" do |select|
+    options.each do |o|
+      select o
+    end
+  end
+end

--- a/features/surveyor.feature
+++ b/features/surveyor.feature
@@ -97,5 +97,21 @@ Feature: Survey creation
     Then the element "input[type='text']:first" should have the class "my_custom_class"
     # Then the element "input[type='text']:last" should not contain the class attribute
     
+  Scenario: Repeater with a dropdown
+    Given the survey
+    """
+      survey "Movies" do
+        section "Preferences" do
+          repeater "What are you favorite genres?" do
+            q "Make", :pick => :one, :display_type => :dropdown
+            a "Action"
+            a "Comedy"
+            a "Mystery"
+          end
+        end
+      end
+    """
+    When I start the "Movies" survey
+    Then a dropdown should exist with the options "Action, Comedy, Mystery"
     
     


### PR DESCRIPTION
When a dropdown exists inside of a repeater, it will display as radio buttons.

<pre>
survey "Movies" do
  section "Preferences" do
    repeater "What are you favorite genres?" do
      q "Make", :pick => :one, :display_type => :dropdown
      a "Action"
      a "Comedy"
      a "Mystery"
    end
  end
end
</pre>
