### PR TITLE
Response set completion time is not saved when a survey is finished

### DIFF
--- a/features/step_definitions/surveyor_steps.rb
+++ b/features/step_definitions/surveyor_steps.rb
@@ -36,3 +36,7 @@ end
 Then /^the element "([^"]*)" should have the class "([^"]*)"$/ do |selector, css_class|
   response.should have_selector(selector, :class => css_class)
 end
+
+Then /^the survey should be complete$/ do
+  ResponseSet.first.should be_complete
+end

--- a/features/surveyor.feature
+++ b/features/surveyor.feature
@@ -57,6 +57,7 @@ Feature: Survey creation
     Then there should be 1 response set with 1 responses with:
       | string_value |
       | beef |
+    Then the survey should be complete
 
     When I start the "Favorites" survey
     And I fill in "food" with "chicken"
@@ -96,6 +97,5 @@ Feature: Survey creation
     When I start the "Movies" survey
     Then the element "input[type='text']:first" should have the class "my_custom_class"
     # Then the element "input[type='text']:last" should not contain the class attribute
-    
     
     

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -74,6 +74,10 @@ module Surveyor
       def complete!
         self.completed_at = Time.now
       end
+      
+      def complete?
+        !completed_at.nil?
+      end
 
       def correct?
         responses.all?(&:correct?)

--- a/lib/surveyor/surveyor_controller_methods.rb
+++ b/lib/surveyor/surveyor_controller_methods.rb
@@ -63,7 +63,8 @@ module Surveyor
       saved = false
       ActiveRecord::Base.transaction do
         saved = @response_set.update_attributes(:responses_attributes => ResponseSet.reject_or_destroy_blanks(params[:r]))
-        saved = @response_set.complete! if saved && params[:finish]
+        @response_set.complete! if saved && params[:finish]
+        saved &= @response_set.save
       end
       return redirect_with_message(surveyor_finish, :notice, t('surveyor.completed_survey')) if saved && params[:finish]
 

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -18,6 +18,7 @@ describe ResponseSet do
     @response_set.complete!
     @response_set.completed_at.should_not be_nil
     @response_set.completed_at.is_a?(Time).should be_true
+    @response_set.should be_complete
   end
 
   it "does not allow completion through mass assignment" do


### PR DESCRIPTION
If you finish a survey and then look at response_sets.completed_at in the database, the column is null.
