### PR TITLE
Fixed uninitialized constant AddDisplayTypeToAnswers::Answer error

### DIFF
--- a/generators/surveyor/templates/migrate/add_display_type_to_answers.rb
+++ b/generators/surveyor/templates/migrate/add_display_type_to_answers.rb
@@ -1,13 +1,28 @@
 class AddDisplayTypeToAnswers < ActiveRecord::Migration
   def self.up
     add_column :answers, :display_type, :string
-    Answer.all.each{|a| a.update_attributes(:display_type => "hidden_label") if a.hide_label == true}
+    set_display_type_to_hidden
     remove_column :answers, :hide_label
   end
 
   def self.down
     add_column :answers, :hide_label, :boolean
-    Answer.all.each{|a| a.update_attributes(:hide_label => true) if a.display_type == "hidden_label"}
+    set_hide_label_to_true
     remove_column :answers, :display_type
   end
+
+  private
+
+  def self.set_display_type_to_hidden
+    if Answer
+      Answer.all.each{|a| a.update_attributes(:display_type => "hidden_label") if a.hide_label == true}
+    end
+  end
+
+  def self.set_hide_label_to_true
+    if Answer
+      Answer.all.each{|a| a.update_attributes(:hide_label => true) if a.display_type == "hidden_label"}
+    end
+  end
+
 end


### PR DESCRIPTION
Fixed uninitialized constant AddDisplayTypeToAnswers::Answer error when executing rake db:migrate on a new Rails app.

I already submited an issue here => https://github.com/NUBIC/surveyor/issues/190
