### PR TITLE
Eliminate the response_set_id validation in Response.

### DIFF
--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -9,7 +9,7 @@ module Surveyor
         @@validations_already_included ||= nil
         unless @@validations_already_included
           # Validations
-          base.send :validates_presence_of, :response_set_id, :question_id, :answer_id
+          base.send :validates_presence_of, :question_id, :answer_id
           
           @@validations_already_included = true
         end

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -69,6 +69,14 @@ describe ResponseSet do
     @response_set.responses.detect{|r| r.question_id == 7}.text_value.should == "Brian is tired"
   end
 
+  it 'saves its responses' do
+    new_set = ResponseSet.new(:survey => Factory(:survey))
+    new_set.responses.build(:question_id => 1, :answer_id => 1, :string_value => 'XXL')
+    new_set.save!
+
+    ResponseSet.find(new_set.id).responses.should have(1).items
+  end
+
   it "should ignore data if corresponding radio button is not selected" do
     @response_set.update_attributes(:responses_attributes => ResponseSet.to_savable(@radio_response_attributes))
     @response_set.responses.select{|r| r.question_id == 2}.should have(1).item

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -10,10 +10,7 @@ describe Response, "when saving a response" do
     @response.should be_valid
   end
 
-  it "should be invalid without a parent response set and question" do
-    @response.response_set_id = nil
-    @response.should have(1).error_on(:response_set_id)
-
+  it "should be invalid without a question" do
     @response.question_id = nil
     @response.should have(1).error_on(:question_id)
   end


### PR DESCRIPTION
This validation makes it impossible to write code like this:

```
rs = ResponseSet.new
rs.responses.build(...)
...
rs.save!
```

because the presence validation introduces a cyclic dependency:
1. a response set saves its new responses, and
2. responses are validated before they are saved;
3. responses must have a response set ID, but
4. the response set ID does not exist until the response set is saved.

However, in the above pattern, ActiveRecord will first save the
ResponseSet, set response_set_id for each associated Response, and then
save each Response.  Therefore, referential integrity can still be
enforced using appropriate NOT NULL and foreign key constaints in
databases that support such constraints.
