### PR TITLE
JSON schemas for the response set.

### DIFF
--- a/doc/api_id_schema.json
+++ b/doc/api_id_schema.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#", 
+    "description": "Public UUID of a Surveyor entity", 
+    "maxLength": 36, 
+    "required": true, 
+    "type": "string"
+}

--- a/doc/response_set_schema.json
+++ b/doc/response_set_schema.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "description": "Response set",
+    "properties": {
+        "api_id": {
+            "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json"
+        },
+        "completed_at": {
+            "format": "date-time",
+            "type": "string"
+        },
+        "created_at": {
+            "format": "date-time",
+            "type": "string"
+        },
+        "responses": {
+            "description": "Responses in the response set",
+            "items": {
+                "properties": {
+                    "answer_id": {
+                        "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json"
+                    },
+                    "api_id": {
+                        "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json"
+                    },
+                    "created_at": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "question_id": {
+                        "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json"
+                    },
+                    "updated_at": {
+                        "format": "date-time",
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": [
+                            "string",
+                            "number",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "type": "array"
+        },
+        "survey_id": {
+            "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json"
+        }
+    }
+}


### PR DESCRIPTION
This commit contains the start of a JSON schema[0] for the JSON representation of a ResponseSet; this is useful for NCS' data synchronization code.

The response set schema references external schemas at `http://download.nubic.northwestern.edu/surveyor/`.  Feel free to change this if the schema are to be published elsewhere.

[0] The schema conforms to draft 03 of the JSON Schema specification (http://json-schema.org/).  Draft 03 expired last year; unfortunately, draft 03 is also the latest draft that has validation tools.

There was an RFC on Draft 04 a while back (https://groups.google.com/group/json-schema/browse_thread/thread/b74f21a05a136b04/2bb7b9f69ec0e4b6?show_docid=2bb7b9f69ec0e4b6), but I haven't seen an official Draft 04 pop up just yet.
