### PR TITLE
Changed version of rake dependency from '0.9.2' to '~>0.9.2'

### DIFF
--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency('rabl', '~>0.6.6')
 
   s.add_development_dependency('yard')
-  s.add_dependency('rake', '0.9.2')
+  s.add_dependency('rake', '~>0.9.2')
   s.add_development_dependency('rspec-rails', '~> 2.9.0')
   s.add_development_dependency('bundler', '~> 1.0', '>= 1.0.21')
   s.add_development_dependency('factory_girl', '~> 2.1.2')


### PR DESCRIPTION
When trying to run the following command:-

```
`$ RAILS_ENV='production' rake surveyor FILE=surveys/kitchen_sink_survey.rb`
```

it generates the following error which i think is due to version conflict. 
    _rake aborted!
    You have already activated rake 0.9.2.2, but your Gemfile requires rake 0.9.2. Using bundle exec may solve this.
    (See full trace by running task with --trace)'_

so this patch, allows all **minor versions** of `rake 0.9.2` which includes `0.9.2.2`. After making this change, the rake error disappears & command executes successfully
