### PR TITLE
Issue #262 - Make survey automatic versioning explicit

### DIFF
--- a/app/views/surveyor/new.html.haml
+++ b/app/views/surveyor/new.html.haml
@@ -7,13 +7,16 @@
   %br
   #survey_list
     %ul
-      - unless @surveys.empty?
-        - @surveys.each do |survey|
+      - unless @codes.empty?
+        - @codes.each do |access_code, values|
           %li
-            = form_tag(take_survey_path(:survey_code => survey.access_code)) do 
+            = form_tag take_survey_path(:survey_code => access_code) do 
               = hidden_field_tag :surveyor_javascript_enabled, false              
-
-              = survey.title
+        
+              = values[:title]
+              &nbsp;
+              = label_tag :survey_version, 'version:'
+              = select_tag(:survey_version, options_for_select([["-- Current version --", ""]] + values[:versions]))
               &nbsp;
               = submit_tag( t('surveyor.take_it') )
       - else

--- a/features/export_to_json.feature
+++ b/features/export_to_json.feature
@@ -39,7 +39,78 @@ Feature: Survey export
         }]
       }
     """
-  
+  Scenario: Exporting versioned survey questions
+  Given I parse
+  """
+    survey "Simple json" do
+      section "Basic questions" do
+        label "These questions are examples of the basic supported input types"
+
+        question_1 "What is your favorite color?", :pick => :one
+        answer "red"
+        answer "blue"
+        answer "green"
+        answer :other
+
+        q_2b "Choose the colors you don't like", :pick => :any
+        a_1 "orange"
+        a_2 "purple"
+        a_3 "brown"
+        a :omit
+      end
+    end
+  """
+  And I parse
+  """
+    survey "Simple json" do
+      section "Not so basic questions" do
+        label "These questions are examples of the basic supported input types"
+
+        question_1 "What is your favorite color?", :pick => :one
+        answer "reddish"
+        answer "blueish"
+        answer "greenish"
+        answer :other
+
+        q_2b "Choose the colors you don't like", :pick => :any
+        a_1 "orange"
+        a_2 "purple"
+        a_3 "brown"
+        a :omit
+      end
+    end
+  """
+  Then the json for "Simple json" should be
+  """
+  {
+    "title": "Simple json",
+    "uuid": "*",
+    "sections": [{
+      "title": "Not so basic questions",
+      "display_order":0,
+      "questions_and_groups": [
+        { "uuid": "*", "type": "label", "text": "These questions are examples of the basic supported input types" },
+        { "uuid": "*", "reference_identifier": "1", "pick": "one", "text": "What is your favorite color?", "answers": [{"text": "reddish", "uuid": "*"}, {"text": "blueish", "uuid": "*"}, {"text": "greenish", "uuid": "*"}, {"text": "Other", "uuid": "*"}]},
+        { "uuid": "*", "reference_identifier": "2b", "pick": "any", "text": "Choose the colors you don't like", "answers": [{"text": "orange", "uuid": "*"},{"text": "purple", "uuid": "*"},{"text": "brown", "uuid": "*"},{"text": "Omit", "exclusive":true, "uuid": "*"}]}]
+      }]
+    }
+  """
+  And the json for "Simple json" version "0" should be
+  """
+  {
+    "title": "Simple json",
+    "uuid": "*",
+    "sections": [{
+      "title": "Basic questions",
+      "display_order":0,
+      "questions_and_groups": [
+        { "uuid": "*", "type": "label", "text": "These questions are examples of the basic supported input types" },
+        { "uuid": "*", "reference_identifier": "1", "pick": "one", "text": "What is your favorite color?", "answers": [{"text": "red", "uuid": "*"}, {"text": "blue", "uuid": "*"}, {"text": "green", "uuid": "*"}, {"text": "Other", "uuid": "*"}]},
+        { "uuid": "*", "reference_identifier": "2b", "pick": "any", "text": "Choose the colors you don't like", "answers": [{"text": "orange", "uuid": "*"},{"text": "purple", "uuid": "*"},{"text": "brown", "uuid": "*"},{"text": "Omit", "exclusive":true, "uuid": "*"}]}]
+      }]
+    }
+  """
+    
   Scenario: Exporting response sets
   Given I parse
   """
@@ -94,3 +165,64 @@ Feature: Survey export
     }]
   }
   """
+  @wip
+  Scenario: Exporting response sets for versioned surveys
+  Given I parse
+  """
+    survey "Simple json response sets" do
+      section "Colors" do
+        question "What is your least favorite color?"
+        a "color", :string
+      end
+    end
+  """
+  And I start the "Simple json response sets" survey
+  And I fill in "color" with "orange"
+  And I press "Click here to finish"
+  And I parse
+  """
+    survey "Simple json response sets" do
+      section "Colors" do
+        question_1 "What is your most favorite color?"
+        a "color", :string
+      end
+    end
+  """
+  And I start the "Simple json response sets" survey
+  And I fill in "color" with "blueish"
+  And I press "Click here to finish"
+  Then the json for the "first" response set for "Simple json response sets" should be
+  """
+  { 
+    "uuid":"*",
+    "survey_id":"*",
+    "created_at":"*",
+    "completed_at":"*",
+    "responses":[{
+      "uuid":"*",
+      "answer_id":"*",
+      "question_id":"*",
+      "created_at":"*",
+      "modified_at":"*",
+      "value":"orange"
+    }]
+  }
+  """
+  And the json for the "last" response set for "Simple json response sets" should be
+  """
+  { 
+    "uuid":"*",
+    "survey_id":"*",
+    "created_at":"*",
+    "completed_at":"*",
+    "responses":[{
+      "uuid":"*",
+      "answer_id":"*",
+      "question_id":"*",
+      "created_at":"*",
+      "modified_at":"*",
+      "value":"blueish"
+    }]
+  }
+  """
+  

--- a/features/step_definitions/surveyor_steps.rb
+++ b/features/step_definitions/surveyor_steps.rb
@@ -89,16 +89,29 @@ Then /^(\d+) responses should exist$/ do |response_count|
 end
 
 Then /^the json for "([^"]*)" should be$/ do |title, string|
-  visit "/surveys/#{Survey.find_by_title(title).access_code}.json"
+  visit "/surveys/#{Survey.to_normalized_string(title)}.json"
   puts page.find('body').text
   Surveyor::Common.equal_json_excluding_wildcards(page.find('body').text, string).should == true
 end
 
-Then /^the json for the last response set for "([^"]*)" should be$/ do |title, string|
-  (survey = Survey.find_by_title(title)).should_not be_nil
-  (response_set = ResponseSet.last(:conditions => {:survey_id => survey.id})).should_not be_nil
-  visit "/surveys/#{survey.access_code}/#{response_set.access_code}.json"
+Then /^the json for "([^"]*)" version "([^"]*)" should be$/ do |title, version, string|
+  visit "/surveys/#{Survey.to_normalized_string(title)}.json?survey_version=#{version}"
   puts page.find('body').text
+  Surveyor::Common.equal_json_excluding_wildcards(page.find('body').text, string).should == true
+end
+
+Then /^the json for the "([^"]*)" response set for "([^"]*)" should be$/ do |order, title, string|
+  response_sets = ResponseSet.joins(:survey).where(:conditions => { :surveys => { :title => title }}).order(:updated_at)
+  response_sets.should_not be_empty
+  
+  case order
+  when "last"
+    response_set = response_sets.last
+  when "first"
+    response_set = response_sets.first
+  end
+  response_set.should_not be_nil    
+  visit "/surveys/#{response_set.survey.access_code}/#{response_set.access_code}.json"
   Surveyor::Common.equal_json_excluding_wildcards(page.find('body').text, string).should == true
 end
 

--- a/features/surveyor.feature
+++ b/features/surveyor.feature
@@ -530,3 +530,38 @@ Feature: Survey creation
     When I uncheck "Singapore"
     And I wait 1 seconds
     Then 0 responses should exist
+    
+  Scenario: Accessing outdated survey
+    Given the survey
+    """
+      survey "Travels" do
+        section "Everything" do
+          q "Which of these countries have you visited?", :pick => :any
+          a "Italy"
+          a "Morocco"
+          a "Mexico"
+        end
+      end
+    """
+    And the survey
+    """
+      survey "Travels" do
+        section "Countries" do
+          q "Which of these countries have you visited?", :pick => :any
+          a "Ireland"
+          a "Kenya"
+          a "Singapore"
+        end
+      end
+    """
+    When I go to the surveys page
+    And I wait 1 seconds
+    And I press "Take it"
+    Then I should see "Ireland"
+    And I should not see "Italy"
+    
+    When I go to the surveys page
+    And I select "0" from "survey_version"
+    And I press "Take it"
+    Then I should see "Mexico"
+    And I should not see "Keniya"

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -12,7 +12,13 @@ module Surveyor
       unless options[:skip_migrations]
         # because all migration timestamps end up the same, causing a collision when running rake db:migrate
         # copied functionality from RAILS_GEM_PATH/lib/rails_generator/commands.rb
-        %w(create_surveys create_survey_sections create_questions create_question_groups create_answers create_response_sets create_responses create_dependencies create_dependency_conditions create_validations create_validation_conditions add_display_order_to_surveys add_correct_answer_id_to_questions add_index_to_response_sets add_index_to_surveys add_unique_indicies add_section_id_to_responses add_default_value_to_answers add_api_ids add_display_type_to_answers add_api_id_to_question_groups add_api_ids_to_response_sets_and_responses update_blank_api_ids_on_question_group).each_with_index do |model, i|
+        %w(create_surveys create_survey_sections create_questions create_question_groups create_answers 
+        create_response_sets create_responses create_dependencies create_dependency_conditions create_validations
+        create_validation_conditions add_display_order_to_surveys add_correct_answer_id_to_questions 
+        add_index_to_response_sets add_index_to_surveys add_unique_indicies add_section_id_to_responses 
+        add_default_value_to_answers add_api_ids add_display_type_to_answers add_api_id_to_question_groups 
+        add_api_ids_to_response_sets_and_responses update_blank_api_ids_on_question_group 
+        drop_unique_index_on_access_code_in_surveys add_version_to_surveys add_unique_index_on_access_code_and_version_in_surveys).each_with_index do |model, i|
           unless (prev_migrations = Dir.glob("db/migrate/[0-9]*_*.rb").grep(/[0-9]+_#{model}.rb$/)).empty?
             prev_migration_timestamp = prev_migrations[0].match(/([0-9]+)_#{model}.rb$/)[1]
           end

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -18,7 +18,7 @@ module Surveyor
         add_index_to_response_sets add_index_to_surveys add_unique_indicies add_section_id_to_responses 
         add_default_value_to_answers add_api_ids add_display_type_to_answers add_api_id_to_question_groups 
         add_api_ids_to_response_sets_and_responses update_blank_api_ids_on_question_group 
-        drop_unique_index_on_access_code_in_surveys add_version_to_surveys add_unique_index_on_access_code_and_version_in_surveys).each_with_index do |model, i|
+        drop_unique_index_on_access_code_in_surveys add_version_to_surveys add_unique_index_on_access_code_and_version_in_surveys update_blank_versions_on_surveys).each_with_index do |model, i|
           unless (prev_migrations = Dir.glob("db/migrate/[0-9]*_*.rb").grep(/[0-9]+_#{model}.rb$/)).empty?
             prev_migration_timestamp = prev_migrations[0].match(/([0-9]+)_#{model}.rb$/)[1]
           end

--- a/lib/generators/surveyor/templates/db/migrate/add_unique_index_on_access_code_and_version_in_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_unique_index_on_access_code_and_version_in_surveys.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexOnAccessCodeAndVersionInSurveys < ActiveRecord::Migration
+  def self.up
+    add_index(:surveys, [ :access_code, :version], :name => 'surveys_access_code_version_idx', :unique => true)
+  end
+
+  def self.down
+    remove_index( :surveys, :name => 'surveys_access_code_version_idx' )
+  end
+end

--- a/lib/generators/surveyor/templates/db/migrate/add_version_to_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/add_version_to_surveys.rb
@@ -1,0 +1,9 @@
+class AddVersionToSurveys < ActiveRecord::Migration
+  def self.up
+    add_column :surveys, :version, :integer, :default => 0
+  end
+
+  def self.down
+    remove_column :surveys, :version
+  end
+end

--- a/lib/generators/surveyor/templates/db/migrate/drop_unique_index_on_access_code_in_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/drop_unique_index_on_access_code_in_surveys.rb
@@ -1,0 +1,9 @@
+class DropUniqueIndexOnAccessCodeInSurveys < ActiveRecord::Migration
+  def self.up
+    remove_index( :surveys, :name => 'surveys_ac_idx' )
+  end
+
+  def self.down
+    add_index(:surveys, :access_code, :name => 'surveys_ac_idx')
+  end
+end

--- a/lib/generators/surveyor/templates/db/migrate/update_blank_versions_on_surveys.rb
+++ b/lib/generators/surveyor/templates/db/migrate/update_blank_versions_on_surveys.rb
@@ -1,0 +1,12 @@
+class Survey < ActiveRecord::Base; end
+class UpdateBlankVersionsOnSurveys < ActiveRecord::Migration
+  def self.up
+    Survey.where('version IS ?', nil).each do |s|
+      s.version = 0
+      s.save!
+    end
+  end
+
+  def self.down
+  end
+end

--- a/lib/surveyor/surveyor_controller_methods.rb
+++ b/lib/surveyor/surveyor_controller_methods.rb
@@ -111,8 +111,14 @@ module Surveyor
     end
     
     def export
-      @survey = Survey.find_by_access_code(params[:survey_code])
+      surveys = Survey.where(:access_code => params[:survey_code]).order("version DESC")
+      if params[:survey_version].blank?
+        @survey = surveys.first
+      else
+        @survey = surveys.where(:version => params[:survey_version]).first
+      end
     end
+    
     private
 
     # This is a hoock method for surveyor-using applications to override and provide the context object

--- a/lib/tasks/surveyor_tasks.rake
+++ b/lib/tasks/surveyor_tasks.rake
@@ -63,12 +63,24 @@ namespace :surveyor do
   desc "dump all responses to a given survey"
   task :dump => :environment do
     require 'fileutils.rb'
-    raise "USAGE: rake surveyor:dump SURVEY_ACCESS_CODE=<access_code> [OUTPUT_DIR=<dir>]" unless ENV["SURVEY_ACCESS_CODE"] 
-    survey = Survey.find_by_access_code(ENV["SURVEY_ACCESS_CODE"])
-    raise "No Survey found with code " + ENV["SURVEY_ACCESS_CODE"] unless survey
+    version = ENV["VERSION"] 
+    access_code = ENV["SURVEY_ACCESS_CODE"]
+    
+    raise "USAGE: rake surveyor:dump SURVEY_ACCESS_CODE=<access_code> [OUTPUT_DIR=<dir>] [VERSION=<version>]" unless access_code
+    params_string = "code #{access_code}"
+
+    surveys = Survey.where(:access_code => access_code).order("version ASC")
+    if version.blank?
+      survey = surveys.last
+    else
+      params_string += " and version #{version}"
+      survey = surveys.where(:version => version).first
+    end
+    
+    raise "No Survey found with #{params_string}" unless survey
     dir = ENV["OUTPUT_DIR"] || Rails.root
     mkpath(dir) # Create all non-existent directories
-    full_path = File.join(dir,"#{survey.access_code}_#{Time.now.to_i}.csv")
+    full_path = File.join(dir,"#{survey.access_code}_v#{survey.version}_#{Time.now.to_i}.csv")
     File.open(full_path, 'w') do |f|
       survey.response_sets.each_with_index{|r,i| f.write(r.to_csv(true, i == 0)) } # print access code every time, print_header first time
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,6 +11,7 @@ Factory.define :survey do |s|
   s.active_at     {Time.now}
   s.inactive_at   {}
   s.css_url       {}
+  s.version       {0}
 end
 
 Factory.sequence(:survey_section_display_order){|n| n }

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -11,15 +11,28 @@ describe Survey, "when saving a new one" do
     @survey.should have(1).error_on(:title)
   end
 
-  it "should adjust the title to save unique titles" do
+  it "should adjust the version to save unique version for each title" do
     original = Survey.new(:title => "Foo")
     original.save.should be_true
+    original.version.should == 0
     imposter = Survey.new(:title => "Foo")
     imposter.save.should be_true
-    imposter.title.should == "Foo 1"
+    imposter.title.should == "Foo"
+    imposter.version.should == 1
     bandwagoneer = Survey.new(:title => "Foo")
     bandwagoneer.save.should be_true
-    bandwagoneer.title.should == "Foo 2"
+    bandwagoneer.title.should == "Foo"
+    bandwagoneer.version.should == 2
+  end
+  
+  it "should not allow to have duplicate versions of the survey" do
+    survey = Survey.new(:title => "Foo")
+    survey.save.should be_true
+    imposter = Survey.new(:title => "Foo")
+    imposter.save.should be_true
+    imposter.version = 0
+    imposter.save.should be_false
+    imposter.should have(1).error_on(:version)
   end
 
   it "should not adjust the title when updating itself" do


### PR DESCRIPTION
If someone loads a survey with a title that matches title of existing survey, new record will have the same title and access code (generated from title) as existing survey and incremented version. 

Surveyor index page lists unique titles for existing surveys and gives an option to select a version to take. If it was not selected, latest version of a survey will be loaded.
