### PR TITLE
Support asset pipeline precompilation

### DIFF
--- a/Gemfile.rails_version
+++ b/Gemfile.rails_version
@@ -7,6 +7,8 @@ if ENV['RAILS_VERSION']
     gem 'rails', '~> 3.0.10'
   when /3.1$/
     gem 'rails', '~> 3.1.0'
+  when /3.2$/
+    gem 'rails', '~> 3.2.0'
   else
     fail "Unknown Rails version #{ENV['RAILS_VERSION']}"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -42,13 +42,24 @@ namespace :testbed do
   task :generate do
     sh 'bundle exec rails new testbed'
     chdir('testbed') do
-      File.open('Gemfile', 'w') do |f|
-        f.puts %q{source :rubygems}
-        f.puts %q{plugin_root = File.expand_path('../..', __FILE__)}
-        f.puts %q{eval(File.read File.join(plugin_root, 'Gemfile.rails_version'))}
-        f.puts %q{gem 'sqlite3'}
-        f.puts %q{gem 'surveyor', :path => plugin_root}
+      gems = File.read('Gemfile')
+      gems.sub!(/gem.*rails.*$/, '')
+
+      unless gems =~ /gem.*sqlite3/
+        gems += %Q{gem 'sqlite'\n}
       end
+
+      unless gems =~ /gem.*jquery-rails/
+        gems += %Q{gem 'jquery-rails'\n}
+      end
+
+      gems += %q{
+plugin_root = File.expand_path('../..', __FILE__)
+eval(File.read(File.join(plugin_root, 'Gemfile.rails_version')))
+gem 'surveyor', :path => plugin_root
+      }
+
+      File.open('Gemfile', 'w') { |f| f.write(gems) }
 
       Bundler.with_clean_env do
         sh 'bundle update'

--- a/app/assets/javascripts/surveyor.js
+++ b/app/assets/javascripts/surveyor.js
@@ -1,0 +1,5 @@
+// = require 'surveyor/jquery.tools.min'
+// = require 'surveyor/jquery-ui'
+// = require 'surveyor/jquery-ui-timepicker-addon'
+// = require 'surveyor/jquery.surveyor'
+// = require 'surveyor/jquery.blockUI'

--- a/app/assets/stylesheets/surveyor.css
+++ b/app/assets/stylesheets/surveyor.css
@@ -1,0 +1,6 @@
+// = require 'surveyor/reset'
+// = require 'surveyor/dateinput'
+// = require 'surveyor/jquery-ui.custom'
+// = require 'surveyor/jquery-ui-timepicker-addon'
+// = require 'sass/surveyor'
+// = require 'sass/custom'

--- a/app/assets/stylesheets/surveyor.css
+++ b/app/assets/stylesheets/surveyor.css
@@ -3,4 +3,3 @@
 // = require 'surveyor/jquery-ui.custom'
 // = require 'surveyor/jquery-ui-timepicker-addon'
 // = require 'sass/surveyor'
-// = require 'sass/custom'

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -30,10 +30,6 @@ module Surveyor
 
       assets = %w(templates/public/images/surveyor)
 
-      if asset_pipeline_enabled?
-        insert_surveyor_load_lines
-      end
-
       if !asset_pipeline_enabled?
         assets += %w( templates/public/javascripts/surveyor templates/public/stylesheets/surveyor templates/public/stylesheets/sass )
       end
@@ -62,6 +58,8 @@ module Surveyor
     end
 
     def insert_surveyor_load_lines
+      return unless asset_pipeline_enabled?
+
       app_js_file = 'app/assets/javascripts/application.js'
       app_css_file = 'app/assets/stylesheets/application.css'
 

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -26,14 +26,19 @@ module Surveyor
     end
 
     def assets
-      return insert_surveyor_load_lines if asset_pipeline_enabled?
-
       asset_directory = "public"
 
-      if Rails.application.config.respond_to?(:assets) && Rails.application.config.assets.enabled == true
-        asset_directory = "vendor/assets"
+      assets = %w(templates/public/images/surveyor)
+
+      if asset_pipeline_enabled?
+        insert_surveyor_load_lines
       end
-      %w( templates/public/images/surveyor templates/public/javascripts/surveyor templates/public/stylesheets/surveyor templates/public/stylesheets/sass ).each do |path|
+
+      if !asset_pipeline_enabled?
+        assets += %w( templates/public/javascripts/surveyor templates/public/stylesheets/surveyor templates/public/stylesheets/sass )
+      end
+
+      assets.each do |path|
         asset_path = File.expand_path("../#{path}", __FILE__)
         Dir.foreach(asset_path) do |f|
           next if File.directory?(f)
@@ -45,11 +50,13 @@ module Surveyor
         end
       end
     end
+
     def surveys
       copy_file "surveys/kitchen_sink_survey.rb"
       copy_file "surveys/quiz.rb"
       copy_file "surveys/date_survey.rb"
     end
+
     def locales
       directory "config/locales"
     end

--- a/lib/surveyor/engine.rb
+++ b/lib/surveyor/engine.rb
@@ -1,12 +1,23 @@
 require 'rails'
 require 'surveyor'
+require 'surveyor/helpers/asset_pipeline'
 require 'haml' # required for view resolution
 
 module Surveyor
   class Engine < Rails::Engine
-    config.autoload_paths << File.expand_path("../../", __FILE__)
-    # rake_tasks do
-    #   load "tasks/surveyor_tasks.rake"
-    # end
+    root = File.expand_path('../../', __FILE__)
+
+    config.autoload_paths << root
+
+    initializer 'surveyor.asset_pipeline', :group => :all do |app|
+      extend Surveyor::Helpers::AssetPipeline
+
+      if asset_pipeline_enabled?
+        app.config.assets.paths += Dir[
+          "#{root}/generators/surveyor/templates/public/*",
+          "#{root}/../app/assets/*"
+        ]
+      end
+    end
   end
 end

--- a/lib/surveyor/helpers/asset_pipeline.rb
+++ b/lib/surveyor/helpers/asset_pipeline.rb
@@ -1,0 +1,13 @@
+module Surveyor
+  module Helpers
+    module AssetPipeline
+      ##
+      # Returns whether or not the asset pipeline is present and enabled.
+      #
+      # The detection scheme used here was ripped from jquery-rails.
+      def asset_pipeline_enabled?
+        ::Rails.version >= "3.1" && ::Rails.application.config.assets.enabled
+      end
+    end
+  end
+end

--- a/lib/surveyor/helpers/surveyor_helper_methods.rb
+++ b/lib/surveyor/helpers/surveyor_helper_methods.rb
@@ -1,8 +1,14 @@
+require 'surveyor/helpers/asset_pipeline'
+
 module Surveyor
   module Helpers
     module SurveyorHelperMethods
+      include AssetPipeline
+
       # Layout: stylsheets and javascripts
       def surveyor_includes
+        return if asset_pipeline_enabled?
+
         surveyor_stylsheets + surveyor_javascripts
       end
       def surveyor_stylsheets


### PR DESCRIPTION
This is a simplification of a patch by @gaurish (#314).  See commit messages for details.

The gist: this patch set fixes asset pipeline precompilation for Rails >= 3.1 applications that use the asset pipeline.  Rails 3.0 applications are not affected.
