### PR TITLE
Survey#as_json doesn't seem to be serializing the survey

### DIFF
--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -70,11 +70,9 @@ module Surveyor
         self.active_at = nil
       end
       def as_json(options = nil)
-        template_path = ActionController::Base.view_paths.find("export", ["surveyor"], false, {:handlers=>[:rabl], :locale=>[:en], :formats=>[:json]}, [], []).inspect
-        engine = Rabl::Engine.new(File.read(template_path))
-        engine.to_hash((options || {}).merge(:object => self))
-      end
-      
+        template_paths = ActionController::Base.view_paths.collect(&:to_path)
+        JSON.parse(Rabl::Renderer.json(self, 'surveyor/export.json', :view_path => template_paths))
+      end      
     end
   end
 end

--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -71,7 +71,7 @@ module Surveyor
       end
       def as_json(options = nil)
         template_paths = ActionController::Base.view_paths.collect(&:to_path)
-        JSON.parse(Rabl::Renderer.json(self, 'surveyor/export.json', :view_path => template_paths))
+        Rabl.render(self, 'surveyor/export.json', :view_path => template_paths, :format => "hash")
       end      
     end
   end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -142,4 +142,19 @@ describe Survey do
     end
     @survey.attributes.should == saved_attrs
   end
+  
+  it "should include title, sections, and questions when serialized" do
+    survey = Factory(:survey, :title => "Foo")
+    s1 = Factory(:survey_section, :survey => survey, :title => "wise")
+    s2 = Factory(:survey_section, :survey => survey, :title => "er")
+    q1 = Factory(:question, :survey_section => s1, :text => "what is wise?")
+    q2 = Factory(:question, :survey_section => s2, :text => "what is er?")
+    q3 = Factory(:question, :survey_section => s2, :text => "what is mill?")
+    
+    actual = survey.as_json
+    actual['title'].should == 'Foo'
+    actual['sections'].size.should == 2
+    actual['sections'][0]['questions_and_groups'].size.should == 1
+    actual['sections'][1]['questions_and_groups'].size.should == 2
+  end
 end

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -152,9 +152,9 @@ describe Survey do
     q3 = Factory(:question, :survey_section => s2, :text => "what is mill?")
     
     actual = survey.as_json
-    actual['title'].should == 'Foo'
-    actual['sections'].size.should == 2
-    actual['sections'][0]['questions_and_groups'].size.should == 1
-    actual['sections'][1]['questions_and_groups'].size.should == 2
+    actual[:title].should == 'Foo'
+    actual[:sections].size.should == 2
+    actual[:sections][0][:questions_and_groups].size.should == 1
+    actual[:sections][1][:questions_and_groups].size.should == 2
   end
 end

--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('formtastic', '~> 1.2.4')
   s.add_dependency('uuidtools', '~> 2.1')
   s.add_dependency('mustache', '0.99.4')
-  s.add_dependency('rabl', '~>0.6.6')
+  s.add_dependency('rabl', '~>0.6.11')
 
   s.add_development_dependency('yard')
   s.add_development_dependency('rake', '>= 0.9.2')


### PR DESCRIPTION
Survey#as_json is returning an empty hash.  I couldn't track down why all of a sudden this is happening, I tried downgrading rabl to 0.6.6 and 0.6.0 to see if older versions of rabl work, but no luck.

I was able to fix the problem and in my fix I'm using rabl's new direct template rendering methods.  The only downside was I wasn't able to figure out a way to render directly to a hash, so I'm rendering json and parsing that into a hash.
