### PR TITLE
ResponseSet #as_json fails to serialize the response set

### DIFF
--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -109,10 +109,9 @@ module Surveyor
       end
       
       def as_json(options = nil)
-        template_path = ActionController::Base.view_paths.find("show", ["surveyor"], false, {:handlers=>[:rabl], :locale=>[:en], :formats=>[:json]}, [], []).inspect
-        engine = Rabl::Engine.new(File.read(template_path))
-        engine.to_hash((options || {}).merge(:object => self))
-      end
+        template_paths = ActionController::Base.view_paths.collect(&:to_path)
+        Rabl.render(self, 'surveyor/show.json', :view_path => template_paths, :format => "hash")
+      end      
       
       def complete!
         self.completed_at = Time.now

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -65,7 +65,7 @@ Factory.define :answer do |a|
   a.short_text                {"clear"}
   a.help_text                 {"Clear is the absense of color"}
   a.weight                    {}
-  a.response_class            {"String"}
+  a.response_class            {"string"}
   a.reference_identifier      {}
   a.data_export_identifier    {}
   a.common_namespace          {}

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -443,3 +443,23 @@ describe ResponseSet, "exporting csv" do
     csv.should match /pecan pie/
   end
 end
+
+describe ResponseSet, "#as_json" do
+  let(:rs) {
+    Factory(:response_set, :responses => [
+          Factory(:response, :question => Factory(:question), :answer => Factory(:answer), :string_value => '2')])
+  }
+  
+  let(:js) {rs.as_json}
+  
+  it "should include uuid, survey_id" do
+    js[:uuid].should == rs.api_id
+  end
+  
+  it "should include responses with uuid, question_id, answer_id, value" do
+    r0 = rs.responses[0]
+    js[:responses][0][:uuid].should == r0.api_id
+    js[:responses][0][:answer_id].should == r0.answer.api_id
+    js[:responses][0][:question_id].should == r0.question.api_id
+  end
+end

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -461,5 +461,6 @@ describe ResponseSet, "#as_json" do
     js[:responses][0][:uuid].should == r0.api_id
     js[:responses][0][:answer_id].should == r0.answer.api_id
     js[:responses][0][:question_id].should == r0.question.api_id
+    js[:responses][0][:value].should == r0.string_value
   end
 end


### PR DESCRIPTION
Currently the response set #as_json method returns an empty hash.  I've fixed the serialization problem and updated #as_json.
