### PR TITLE
JSON representation of Response must include response_group

### DIFF
--- a/app/views/surveyor/show.json.rabl
+++ b/app/views/surveyor/show.json.rabl
@@ -8,6 +8,7 @@ child (@response_set.responses || []) => :responses do
   attribute :api_id => :uuid
   attribute :created_at
   attribute :updated_at => :modified_at
+  attribute :response_group
   node(:answer_id){|r| r.answer.api_id }
   node(:question_id){|r| r.question.api_id }
   node(:value, :if => lambda{|r| r.answer.response_class != "answer"}){|r| r.as(r.answer.response_class) }

--- a/doc/response_set_schema.json
+++ b/doc/response_set_schema.json
@@ -21,6 +21,12 @@
                     "question_id": {
                         "$ref": "http://download.nubic.northwestern.edu/surveyor/api_id_schema.json#"
                     },
+                    "response_group": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
                     "updated_at": {
                         "$ref": "http://download.nubic.northwestern.edu/surveyor/surveyor_timestamp_schema.json#"
                     },

--- a/features/export_to_json.feature
+++ b/features/export_to_json.feature
@@ -152,12 +152,14 @@ Feature: Survey export
       "uuid":"*",
       "answer_id":"*",
       "question_id":"*",
+      "response_group":null,
       "created_at":"*",
       "modified_at":"*"
     },{
       "uuid":"*",
       "answer_id":"*",
       "question_id":"*",
+      "response_group":null,
       "created_at":"*",
       "modified_at":"*",
       "value":"orange"
@@ -225,6 +227,7 @@ Feature: Survey export
       "uuid":"*",
       "answer_id":"*",
       "question_id":"*",
+      "response_group":null,
       "created_at":"*",
       "modified_at":"*",
       "value":"orange"
@@ -242,6 +245,7 @@ Feature: Survey export
       "uuid":"*",
       "answer_id":"*",
       "question_id":"*",
+      "response_group":null,
       "created_at":"*",
       "modified_at":"*",
       "value":"blueish"


### PR DESCRIPTION
The `response_group` attribute (appears to be) critical to dealing with repeated sections; therefore, clients such as NUSurveyor and NCS Navigator Cases' sync code require that that attribute be present in the JSON representation of Response.
