### PR TITLE
Fixed a problem with correct_answer not refering to the right answer under "certain" circumstance

### DIFF
--- a/lib/surveyor/models/question_methods.rb
+++ b/lib/surveyor/models/question_methods.rb
@@ -9,7 +9,7 @@ module Surveyor
         base.send :belongs_to, :question_group, :dependent => :destroy
         base.send :has_many, :answers, :order => "display_order ASC", :dependent => :destroy # it might not always have answers
         base.send :has_one, :dependency, :dependent => :destroy
-        base.send :has_one, :correct_answer, :class_name => "Answer", :dependent => :destroy
+        base.send :belongs_to, :correct_answer, :class_name => "Answer", :dependent => :destroy
 
         # Scopes
         base.send :default_scope, :order => "display_order ASC"


### PR DESCRIPTION
In the Question model, the reference to correct_answer should be belongs_to as the correct_answer_id is located in the questions table.
