### PR TITLE
Create default identifiers in before_create, not in the initializer.

### DIFF
--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -28,6 +28,9 @@ module Surveyor
         # Whitelisting attributes
         base.send :attr_accessible, :survey, :responses_attributes, :user_id, :survey_id
 
+        base.send :before_create, :ensure_start_timestamp
+        base.send :before_create, :ensure_identifiers
+
         # Class methods
         base.instance_eval do
           def has_blank_value?(hash)
@@ -38,14 +41,11 @@ module Surveyor
         end
       end
 
-      # Instance methods
-      def initialize(*args)
-        super(*args)
-        default_args
+      def ensure_start_timestamp
+        self.started_at ||= Time.now
       end
 
-      def default_args
-        self.started_at ||= Time.now
+      def ensure_identifiers
         self.access_code ||= random_unique_access_code
         self.api_id ||= Surveyor::Common.generate_api_id
       end


### PR DESCRIPTION
Setting these values in ResponseSet's initialization code has this
rather odd consequence:

```
>> rs = ResponseSet.new
>> rs.changed?  # => true
```

This isn't prohibited by ActiveRecord, but I think it's wrong.
ActiveRecord model initializers should only modify the model when the
programmer requests a change:

```
>> rs = ResponseSet.new(:started_at => Time.now - 100)
>> rs.changed?  # => true
```

Additionally, this mutation-on-initialization paradigm causes problems
for NCS Navigator Cases' merge tests, which expect existing models
without incoming changes to not be changed by the merge process.
