### PR TITLE
Eliminate unnecessary (and incorrect) access code uniqueness checks

### DIFF
--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -46,18 +46,9 @@ module Surveyor
 
       def default_args
         self.started_at ||= Time.now
-        self.access_code ||= random_unique_access_code
+        self.access_code ||= Surveyor::Common.make_tiny_code
         self.api_id ||= Surveyor::Common.generate_api_id
       end
-
-      def random_unique_access_code
-        val = Surveyor::Common.make_tiny_code
-        while ResponseSet.find_by_access_code(val)
-          val = Surveyor::Common.make_tiny_code
-        end
-        val
-      end
-      private :random_unique_access_code
 
       def to_csv(access_code = false, print_header = true)
         qcols = Question.content_columns.map(&:name) - %w(created_at updated_at)

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -55,14 +55,6 @@ describe ResponseSet do
       rs2.should_not be_valid
       rs2.should have(1).errors_on(:access_code)
     end
-
-    it 'defaults to a random, non-conflicting value on init' do
-      Surveyor::Common.should_receive(:make_tiny_code).and_return('one')
-      Surveyor::Common.should_receive(:make_tiny_code).and_return('two')
-      Surveyor::Common.should_receive(:make_tiny_code).and_return('three')
-
-      ResponseSet.new.access_code.should == 'three'
-    end
   end
 
   it "is completable" do


### PR DESCRIPTION
This set of commits eliminates the find-loop done in ResponseSet's initializer.

IMO, `.new` on ActiveRecord models shouldn't kick off database queries.  However, probably more important than that is that _the entire check is ill-conceived_ and is just slowing down ResponseSet initialization; the access code uniqueness check is subject to the same fundamental problem affecting  `validates_uniqueness_of`.

This pull request also replaces the access code generator with one using `SecureRandom` and provides an analysis of its collision probability.  I find it to be sufficiently low (given 10,000 response sets, there's a 1:1.5 billion chance of a collision); however, I would appreciate a double-check on the math and the arithmetic.

Note, too, that even with its current code, Surveyor is still prone to access code collisions.  To truly handle collisions, Surveyor needs code to
1. catch a uniqueness violation as signaled by the database,
2. generate a new access code, and 
3. restart the transaction.
