### PR TITLE
Fixes bug #375: Grid answers leaking from question to question

### DIFF
--- a/lib/surveyor/parser.rb
+++ b/lib/surveyor/parser.rb
@@ -172,6 +172,7 @@ module SurveyorParserQuestionGroupMethods
   end
   def clear(context)
     [ :question_group,
+      :grid_answers,
       :question,
       :dependency,
       :dependency_condition,


### PR DESCRIPTION
In the lib/surveyor/parser.rb file
    the :grid_answers context was not being cleared in the module 

SurveyorParserQuestionGroupMethods
    insert :grid_answers, into line 175
