### PR TITLE
response_set_methods.rb has unconditional require of fastercsv

### DIFF
--- a/lib/surveyor/common.rb
+++ b/lib/surveyor/common.rb
@@ -37,6 +37,23 @@ module Surveyor
       def generate_api_id
         UUIDTools::UUID.random_create.to_s
       end
+
+      ##
+      # @private Intended for internal use only.
+      #
+      # Loads and uses either `FasterCSV` (for Ruby 1.8) or the stdlib `CSV`
+      # (for Ruby 1.9+).
+      #
+      # @return [Class] either `CSV` for `FasterCSV`.
+      def csv_impl
+        @csv_impl ||= if RUBY_VERSION < '1.9'
+                         require 'fastercsv'
+                         FasterCSV
+                       else
+                         require 'csv'
+                         CSV
+                       end
+      end
     end
   end
 end

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -1,5 +1,3 @@
-require 'fastercsv'
-require 'csv'
 require 'rabl'
 
 module Surveyor
@@ -54,8 +52,7 @@ module Surveyor
         qcols = Question.content_columns.map(&:name) - %w(created_at updated_at)
         acols = Answer.content_columns.map(&:name) - %w(created_at updated_at)
         rcols = Response.content_columns.map(&:name)
-        csvlib = CSV.const_defined?(:Reader) ? FasterCSV : CSV
-        result = csvlib.generate do |csv|
+        result = Surveyor::Common.csv_impl.generate do |csv|
           if print_header
             csv << (access_code ? ["response set access code"] : []) +
               qcols.map{|qcol| "question.#{qcol}"} +

--- a/lib/surveyor/redcap_parser.rb
+++ b/lib/surveyor/redcap_parser.rb
@@ -1,7 +1,5 @@
 %w(survey survey_section question_group question dependency dependency_condition answer validation validation_condition).each {|model| require model }
 require 'active_support' # for humanize
-require 'fastercsv'
-require 'csv'
 module Surveyor
   class RedcapParserError < StandardError; end
   class RedcapParser
@@ -28,7 +26,7 @@ module Surveyor
       self.context[:dependency_conditions] = []
     end
     def parse(str, filename)
-      csvlib = CSV.const_defined?(:Reader) ? FasterCSV : CSV
+      csvlib = Surveyor::Common.csv_impl
       begin
         csvlib.parse(str, :headers => :first_row, :return_headers => true, :header_converters => :symbol) do |r|
           if r.header_row? # header row


### PR DESCRIPTION
`lib/surveyor/models/response_set_methods.rb` includes an unconditional require of `fastercsv`. While the code itself seems to correctly use `FasterCSV` or `CSV` based on context, the fact that `fastercsv` is required at all can interfere with other `CSV`-using code in the same application which hosts Surveyor.

This is possible because both `CSV` and `FasterCSV` define some of the same methods on common classes. For example, both define `Array#to_csv`. In the usual ruby way, the last code to define this method wins. Since Surveyor requires `fastercsv` first, it seems like `CSV` would always win. However, if other code in the host application requires `csv` before `surveyor/models/response_set_methods` is loaded, `fastercsv` will be the last code to define `Array#to_csv`. When this happens, a call to `CSV::Row#to_csv` will throw the following incongruous exception:

```
NotImplementedError:
  Please switch to Ruby 1.9's standard CSV library.  It's FasterCSV plus support for Ruby 1.9's m17n encoding engine.
# /Users/rsutphin/.rvm/gems/ruby-1.9.3-p194/gems/fastercsv-1.5.5/lib/faster_csv.rb:13:in `const_missing'
# /Users/rsutphin/.rvm/gems/ruby-1.9.3-p194/gems/fastercsv-1.5.5/lib/faster_csv.rb:19:in `method_missing'
# /Users/rsutphin/.rvm/gems/ruby-1.9.3-p194/gems/fastercsv-1.5.5/lib/faster_csv.rb:2016:in `to_csv'
# /Users/rsutphin/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/csv.rb:496:in `to_csv'
```

Surveyor should not require `fastercsv` at all if it is running on Ruby 1.9 or later.
