### PR TITLE
References #401 - Moves the help text to be after the answer text.

### DIFF
--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -4,7 +4,6 @@
 - i = response_idx(q.pick != "one") # argument will be false (don't increment i) if we're on radio buttons
 - disabled = defined?(disableFlag) ? disableFlag : false
 = f.semantic_fields_for i, r do |ff|
-  %span.help= render_help_text(a, @render_context) unless g && g.display_type == "grid"
   = ff.input :question_id, :as => :quiet unless q.pick == "one" # don't repeat question_id if we're on radio buttons
   = ff.input :api_id, :as => :quiet unless q.pick == "one"
   = ff.input :response_group, :value => rg, :as => :quiet if q.pick != "one" && g && g.display_type == "repeater"
@@ -19,3 +18,4 @@
       = ff.input rc_to_attr(a.response_class), :as => rc_to_as(a.response_class), :label => a_text(a, :pre, @render_context).blank? ? false : a_text(a, :pre, @render_context), :hint => a_text(a, :post, @render_context), :input_html => generate_pick_none_input_html(r.as(a.response_class), a.default_value, a.css_class, a.response_class, disabled)
     - else
       = a_text(a, nil, @render_context)
+  %span.help= render_help_text(a, @render_context) unless g && g.display_type == "grid"


### PR DESCRIPTION
Pull request to move the `help_text` rendering in the `app/views/partials/_answer.haml` partial so that it appears after the answer text, not before.

Related to #373 and #401 
