### PR TITLE
References #404 - Added `html_safe` call to the non-image answer type in...

### DIFF
--- a/lib/surveyor/helpers/surveyor_helper_methods.rb
+++ b/lib/surveyor/helpers/surveyor_helper_methods.rb
@@ -67,7 +67,7 @@ module Surveyor
       # Answers
       def a_text(obj, pos=nil, context = nil)
         return image_tag(obj.text) if obj.is_a?(Answer) and obj.display_type == "image"
-        obj.split_or_hidden_text(pos, context)
+        obj.split_or_hidden_text(pos, context).html_safe
       end
 
       def rc_to_attr(type_sym)

--- a/spec/helpers/surveyor_helper_spec.rb
+++ b/spec/helpers/surveyor_helper_spec.rb
@@ -61,6 +61,12 @@ describe SurveyorHelper do
     helper.a_text(a2, nil, FakeMustacheContext).should == "Yes, I do work for Northwestern"
   end
 
+  it "should return html_safe text for answer" do
+    q1 = Factory(:question, :text => "Do you work for {{site}}", :answers => [a1 = Factory(:answer, :text => "No, I don't work for {{site}}"), a2 = Factory(:answer, :text => "Yes, I do work for {{site}}") ])
+    helper.a_text(a1, nil, FakeMustacheContext).html_safe?.should be_true
+  end
+  
+
   it "should return the group text with number" do
     g1 = Factory(:question_group)
     helper.q_text(g1, FakeMustacheContext).should == "<span class='qnum'>1) </span>#{g1.text}"


### PR DESCRIPTION
...side the `a_text` helper. Included a test to cover it.

Resolves issue #404 
