### PR TITLE
Remove :order on Suvey -> SurveySection Relationship

### DIFF
--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -6,7 +6,7 @@ module Surveyor
     module SurveyMethods
       def self.included(base)
         # Associations
-        base.send :has_many, :sections, :class_name => "SurveySection", :order => 'display_order', :dependent => :destroy
+        base.send :has_many, :sections, :class_name => "SurveySection", :dependent => :destroy
         base.send :has_many, :sections_with_questions, :include => :questions, :class_name => "SurveySection", :order => 'display_order'
         base.send :has_many, :response_sets
 


### PR DESCRIPTION
This patch removes the :order clause on the Survey model for retrieving the SurveySection relationship.  The addition of the default_scope on SurveySection has resulted in the resulting SQL statements from doubling up on ORDER BY clauses, as covered in #411.
