### PR TITLE
Add extension point for pre-JSON-export survey modifications 

### DIFF
--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -63,10 +63,19 @@ module Surveyor
         self.inactive_at = DateTime.now
         self.active_at = nil
       end
+
       def as_json(options = nil)
         template_paths = ActionController::Base.view_paths.collect(&:to_path)
-        Rabl.render(self, 'surveyor/export.json', :view_path => template_paths, :format => "hash")
+        Rabl.render(filtered_for_json, 'surveyor/export.json', :view_path => template_paths, :format => "hash")
       end
+
+      ##
+      # A hook that allows the survey object to be modified before it is
+      # serialized by the #as_json method.
+      def filtered_for_json
+        self
+      end
+      protected :filtered_for_json
 
       def default_access_code
         self.class.to_normalized_string(title)


### PR DESCRIPTION
Add an extension point in `SurveyMethods` which will allow the application to modify the survey in flight as it is being exported.

The initial motivation for this is to interpret selected custom_classes in an application's existing survey definitions into input masks (#415) for consumption by `nu_surveyor`.

Sketch:

``` ruby
module Surveyor::Models::SurveyMethods
  def as_json
    # ...
    Rabl.render(filtered_for_json, 'surveyor/export.json', :view_path => template_paths, :format => "hash")
  end

  ##
  # Useful documentation here.
  def filtered_for_json
    # return same survey by default
    self
  end
  protected :filter_for_json
end
```
