### PR TITLE
specify source of survey when parsing #429

### DIFF
--- a/features/internationalization.feature
+++ b/features/internationalization.feature
@@ -8,7 +8,9 @@ Feature: Internationalization
   Given I parse
     """
     survey "One language is never enough" do
-      translations :es => "translations/languages.es.yml", :he => "translations/languages.he.yml", :ko => "translations/languages.ko.yml"
+      translations :es => {"title"=>"Un idioma nunca es suficiente", "survey_sections"=>{"one"=>{"title"=>"Uno"}}, "question_groups"=>{"hello"=>{"text"=>"¡Hola!"}}, "questions"=>{"name"=>{"text"=>"¿Cómo se llama Usted?", "answers"=>{"name"=>{"help_text"=>"Mi nombre es..."}}}}}
+      translations :he => {"title"=>"ידיעת שפה אחת אינה מספיקה", "survey_sections"=>{"one"=>{"title"=>"אחת"}}, "question_groups"=>{"hello"=>{"text"=>"שלום"}}, "questions"=>{"name"=>{"text"=>"מה שמך?", "answers"=>{"name"=>{"help_text"=>"שמי..."}}}}}
+      translations :ko => {"title"=>"한가지 언어로는 충분치 않습니다.", "survey_sections"=>{"one"=>{"title"=>"하나"}}, "question_groups"=>{"hello"=>{"text"=>"안녕하십니까"}}, "questions"=>{"name"=>{"text"=>"성함이 어떻게 되십니까?", "answers"=>{"name"=>{"help_text"=>"제 이름은 ... 입니다"}}}}}
       section_one "One" do
         g_hello "Hello" do
           q_name "What is your name?"

--- a/lib/surveyor/parser.rb
+++ b/lib/surveyor/parser.rb
@@ -12,7 +12,7 @@ module Surveyor
 
     # Class methods
     def self.parse_file(filename, options={})
-      self.parse(File.read(filename),{:source => filename}.merge(options))
+      self.parse(File.read(filename),{:filename => filename}.merge(options))
     end
     def self.parse(str, options={})
       self.ensure_attrs
@@ -183,7 +183,7 @@ end
 # SurveySection model
 module SurveyorParserSurveyTranslationMethods
   def parse_and_build(context, args, original_method, reference_identifier)
-    dir = Surveyor::Parser.options[:source].nil? ? Dir.pwd : File.dirname(Surveyor::Parser.options[:source])
+    dir = Surveyor::Parser.options[:filename].nil? ? Dir.pwd : File.dirname(Surveyor::Parser.options[:filename])
     # build, no change in context
     args[0].each do |k,v|
       case v

--- a/lib/surveyor/parser.rb
+++ b/lib/surveyor/parser.rb
@@ -11,8 +11,8 @@ module Surveyor
     attr_accessor :context
 
     # Class methods
-    def self.parsef(f, options={})
-      self.parse(File.read(f),{:source => f}.merge(options))
+    def self.parse_file(filename, options={})
+      self.parse(File.read(filename),{:source => filename}.merge(options))
     end
     def self.parse(str, options={})
       self.ensure_attrs

--- a/lib/tasks/surveyor_tasks.rake
+++ b/lib/tasks/surveyor_tasks.rake
@@ -7,7 +7,7 @@ namespace :surveyor do
     file = File.join(Rails.root, ENV["FILE"])
     raise "File does not exist: #{file}" unless FileTest.exists?(file)
     puts "--- Parsing #{file} ---"
-    Surveyor::Parser.parse(File.read(file), {:trace => Rake.application.options.trace})
+    Surveyor::Parser.parsef(file, {:trace => Rake.application.options.trace})
     puts "--- Done #{file} ---"
   end
   desc "generate and load survey from REDCap Data Dictionary (specify FILE=surveys/redcap.csv)"

--- a/lib/tasks/surveyor_tasks.rake
+++ b/lib/tasks/surveyor_tasks.rake
@@ -7,7 +7,7 @@ namespace :surveyor do
     file = File.join(Rails.root, ENV["FILE"])
     raise "File does not exist: #{file}" unless FileTest.exists?(file)
     puts "--- Parsing #{file} ---"
-    Surveyor::Parser.parsef(file, {:trace => Rake.application.options.trace})
+    Surveyor::Parser.parse_file(file, {:trace => Rake.application.options.trace})
     puts "--- Done #{file} ---"
   end
   desc "generate and load survey from REDCap Data Dictionary (specify FILE=surveys/redcap.csv)"

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -101,7 +101,7 @@ survey "One language is never enough" do
 END
 
           sf = Tempfile.new('surveyor:parser_spec.rb',dir);sf.write(s);sf.flush
-          Surveyor::Parser.parsef(sf)
+          Surveyor::Parser.parse_file(sf)
           survey = Survey.where(:title=>'One language is never enough').first
           survey.nil?.should == false
           survey.translation(:es)['title'].should == "Un idioma nunca es suficiente"

--- a/spec/lib/parser_spec.rb
+++ b/spec/lib/parser_spec.rb
@@ -57,8 +57,8 @@ END
 
   context 'when a translation is specified as a String' do
 
-    context 'when the source is not given' do
-      it 'should look for the translation file in pwd' do
+    context 'when the survey filename is not given' do
+      it 'should look for the translation file relative to pwd' do
         Dir.mktmpdir do |dir|
           FileUtils.cd(dir) do
             t = YAML::dump({'title' => 'Un idioma nunca es suficiente'})
@@ -83,8 +83,8 @@ END
         end
       end
     end
-    context 'when the source is given' do
-      it 'should look for the translation file at the given source' do
+    context 'when the survey filename is given' do
+      it 'should look for the translation file relative to the survey directory' do
         Dir.mktmpdir do |dir|
           t = YAML::dump({'title' => 'Un idioma nunca es suficiente'})
             tf = Tempfile.new('surveyor:parser_spec.rb',dir);tf.write(t);tf.flush


### PR DESCRIPTION
Surveyor::Parser now takes an options[:source] parameter, the given directory
will be searched when looking for translations. If a directory is not
provided the pwd is used.

Translations can now be specified inline using a hash.
