### PR TITLE
Bug fix for RedCap Parser for DependencyConditions

### DIFF
--- a/features/step_definitions/parser_steps.rb
+++ b/features/step_definitions/parser_steps.rb
@@ -61,7 +61,7 @@ Then /^there should be (\d+) question(?:s?) with:$/ do |x, table|
       hash["is_mandatory"] = (hash["is_mandatory"] == "true" ? true : (hash["is_mandatory"] == "false" ? false : hash["is_mandatory"]))
     end
     result = Question.find(:first, :conditions => hash)
-    p hash if result.nil?
+    puts hash if result.nil?
     result.should_not be_nil
   end
 end

--- a/features/step_definitions/parser_steps.rb
+++ b/features/step_definitions/parser_steps.rb
@@ -61,7 +61,7 @@ Then /^there should be (\d+) question(?:s?) with:$/ do |x, table|
       hash["is_mandatory"] = (hash["is_mandatory"] == "true" ? true : (hash["is_mandatory"] == "false" ? false : hash["is_mandatory"]))
     end
     result = Question.find(:first, :conditions => hash)
-    puts hash if result.nil?
+    p hash if result.nil?
     result.should_not be_nil
   end
 end
@@ -88,7 +88,22 @@ end
 
 Then /^there should be (\d+) resolved dependency_condition(?:s?) with:$/ do |x, table|
   DependencyCondition.count.should == x.to_i
+  
   table.hashes.each do |hash|
+    if hash.has_key?("question_reference")
+      question = Question.find_by_reference_identifier(hash.delete("question_reference"))
+      question.should_not be_nil
+      
+      hash.merge!({ :question_id => question.id })
+      
+      if hash.has_key?("answer_reference")
+        answer = Answer.find(:first, :conditions => { :question_id => question.id, :reference_identifier => hash.delete("answer_reference") })
+        answer.should_not be_nil
+        
+        hash.merge!({ :answer_id => answer.id })
+      end
+    end
+   
     d = DependencyCondition.find(:first, :conditions => hash)
     d.should_not be_nil
     d.question.should_not be_nil

--- a/features/z_redcap_parser.feature
+++ b/features/z_redcap_parser.feature
@@ -21,12 +21,12 @@ Feature: Survey import from REDCap
     And there should be 2 dependencies with:
       | rule    |
       | A       |
-      | A and B |				
+      | A and B |
   Scenario: Question level dependencies from REDCap
     Given I parse redcap file "redcap_siblings.csv"
     Then there should be 1 survey with:
-      | title 				|
-      | redcap_siblings.csv |
+      ||
+      ||
     And there should be 1 section with:
       ||
     And there should be 2 questions with:

--- a/features/z_redcap_parser.feature
+++ b/features/z_redcap_parser.feature
@@ -14,14 +14,20 @@ Feature: Survey import from REDCap
     And there should be 233 answers with:
       ||
     And there should be 3 resolved dependency_conditions with:
-      ||
+      | rule_key	| operator	| question_reference | answer_reference |
+      | A	 		| ==		| sex				 | 0	  			|
+      | A	 		| ==		| sex				 | 0	  			|
+      | B	 		| ==		| given_birth		 | 1	  			|	
     And there should be 2 dependencies with:
       | rule    |
       | A       |
-      | A and B |
+      | A and B |				
   Scenario: Question level dependencies from REDCap
     Given I parse redcap file "redcap_siblings.csv"
     Then there should be 1 survey with:
+      | title 				|
+      | redcap_siblings.csv |
+    And there should be 1 section with:
       ||
     And there should be 2 questions with:
       ||

--- a/features/z_redcap_parser.feature
+++ b/features/z_redcap_parser.feature
@@ -26,9 +26,6 @@ Feature: Survey import from REDCap
     Given I parse redcap file "redcap_siblings.csv"
     Then there should be 1 survey with:
       ||
-      ||
-    And there should be 1 section with:
-      ||
     And there should be 2 questions with:
       ||
     And there should be 2 answers with:

--- a/lib/surveyor/redcap_parser.rb
+++ b/lib/surveyor/redcap_parser.rb
@@ -30,7 +30,7 @@ module Surveyor
       begin
         csvlib.parse(str, :headers => :first_row, :return_headers => true, :header_converters => :symbol) do |r|
           if r.header_row? # header row
-            return Surveyor::RedcapParser.rake_trace("Missing headers: #{missing_columns(r.headers).inspect}\n\n") unless missing_columns(r.headers).blank?
+            return Surveyor::RedcapParser.rake_trace "Missing headers: #{missing_columns(r.headers).inspect}\n\n" unless missing_columns(r.headers).blank?
             context[:survey] = Survey.new(:title => filename)
             Surveyor::RedcapParser.rake_trace "survey_#{context[:survey].access_code} "
           else # non-header rows
@@ -63,13 +63,11 @@ module Surveyor
     def resolve_references
       context[:dependency_conditions].each do |dc|
         Surveyor::RedcapParser.rake_trace "resolve(#{dc.question_reference},#{dc.answer_reference})"
-        
         if dc.answer_reference.blank? and (context[:question_references][dc.question_reference].answers.size == 1)
           Surveyor::RedcapParser.rake_trace "...found "
           dc.question = context[:question_references][dc.question_reference]
           dc.answer = dc.question.answers.first
         elsif answer = context[:answer_references][dc.question_reference][dc.answer_reference]
-
           Surveyor::RedcapParser.rake_trace "...found "
           dc.answer = answer
           dc.question = context[:question_references][dc.question_reference]
@@ -108,7 +106,6 @@ module SurveyorRedcapParserQuestionMethods
       context[:survey_section].questions.build({:display_type => "label", :text => r[:section_header], :display_order => context[:survey_section].questions.size})
       Surveyor::RedcapParser.rake_trace "label_ "
     end
-    
     self.attributes = ({
       :reference_identifier => r[:variable__field_name],
       :text => r[:field_label],
@@ -119,7 +116,6 @@ module SurveyorRedcapParserQuestionMethods
       :display_order => context[:survey_section].questions.size
     })
     context[:survey_section].questions << context[:question] = self
-   
     unless context[:question].reference_identifier.blank?
       context[:question_references] ||= {}
       context[:question_references][context[:question].reference_identifier] = context[:question]
@@ -141,12 +137,10 @@ module SurveyorRedcapParserDependencyMethods
       # TODO: forgot to tie rule key to component, counting on the sequence of components
       letters = ('A'..'Z').to_a
       hash = decompose_rule(bl)
-
       self.attributes = {:rule => hash[:rule]}
       context[:question].dependency = context[:dependency] = self
       hash[:components].each do |component|
         dc = context[:dependency].dependency_conditions.build(decompose_component(component).merge({ :rule_key => letters.shift } ))
-        
         context[:dependency_conditions] << dc
       end
       Surveyor::RedcapParser.rake_trace "dependency(#{hash[:rule]}) "

--- a/lib/surveyor/redcap_parser.rb
+++ b/lib/surveyor/redcap_parser.rb
@@ -30,7 +30,7 @@ module Surveyor
       begin
         csvlib.parse(str, :headers => :first_row, :return_headers => true, :header_converters => :symbol) do |r|
           if r.header_row? # header row
-            return Surveyor::RedcapParser.rake_trace "Missing headers: #{missing_columns(r.headers).inspect}\n\n" unless missing_columns(r.headers).blank?
+            return Surveyor::RedcapParser.rake_trace("Missing headers: #{missing_columns(r.headers).inspect}\n\n") unless missing_columns(r.headers).blank?
             context[:survey] = Survey.new(:title => filename)
             Surveyor::RedcapParser.rake_trace "survey_#{context[:survey].access_code} "
           else # non-header rows
@@ -62,16 +62,17 @@ module Surveyor
     end
     def resolve_references
       context[:dependency_conditions].each do |dc|
-        return unless dc.lookup_reference
         Surveyor::RedcapParser.rake_trace "resolve(#{dc.question_reference},#{dc.answer_reference})"
-        if dc.answer_reference.blank? and (row = dc.lookup_reference.find{|r| r[0] == dc.question_reference and r[1] == nil}) and row[2].answers.size == 1
+        
+        if dc.answer_reference.blank? and (context[:question_references][dc.question_reference].answers.size == 1)
           Surveyor::RedcapParser.rake_trace "...found "
-          dc.question = row[2]
+          dc.question = context[:question_references][dc.question_reference]
           dc.answer = dc.question.answers.first
-        elsif row = dc.lookup_reference.find{|r| r[0] == dc.question_reference and r[1] == dc.answer_reference}
+        elsif answer = context[:answer_references][dc.question_reference][dc.answer_reference]
+
           Surveyor::RedcapParser.rake_trace "...found "
-          dc.answer = row[2]
-          dc.question = dc.answer.question
+          dc.answer = answer
+          dc.question = context[:question_references][dc.question_reference]
         else
           Surveyor::RedcapParser.rake_trace "\n!!! failed lookup for dependency_condition q: #{question_reference} a: #{question_reference}"
         end
@@ -107,6 +108,7 @@ module SurveyorRedcapParserQuestionMethods
       context[:survey_section].questions.build({:display_type => "label", :text => r[:section_header], :display_order => context[:survey_section].questions.size})
       Surveyor::RedcapParser.rake_trace "label_ "
     end
+    
     self.attributes = ({
       :reference_identifier => r[:variable__field_name],
       :text => r[:field_label],
@@ -117,9 +119,10 @@ module SurveyorRedcapParserQuestionMethods
       :display_order => context[:survey_section].questions.size
     })
     context[:survey_section].questions << context[:question] = self
+   
     unless context[:question].reference_identifier.blank?
-      context[:lookup] ||= []
-      context[:lookup] << [context[:question].reference_identifier, nil, context[:question]]
+      context[:question_references] ||= {}
+      context[:question_references][context[:question].reference_identifier] = context[:question]
     end
     Surveyor::RedcapParser.rake_trace "question_#{context[:question].reference_identifier} "
   end
@@ -138,10 +141,12 @@ module SurveyorRedcapParserDependencyMethods
       # TODO: forgot to tie rule key to component, counting on the sequence of components
       letters = ('A'..'Z').to_a
       hash = decompose_rule(bl)
+
       self.attributes = {:rule => hash[:rule]}
       context[:question].dependency = context[:dependency] = self
       hash[:components].each do |component|
-        dc = context[:dependency].dependency_conditions.build(decompose_component(component).merge(:lookup_reference => context[:lookup], :rule_key => letters.shift))
+        dc = context[:dependency].dependency_conditions.build(decompose_component(component).merge({ :rule_key => letters.shift } ))
+        
         context[:dependency_conditions] << dc
       end
       Surveyor::RedcapParser.rake_trace "dependency(#{hash[:rule]}) "
@@ -193,8 +198,8 @@ end
 # DependencyCondition model
 module SurveyorRedcapParserDependencyConditionMethods
   DependencyCondition.instance_eval do
-    attr_accessor :question_reference, :answer_reference, :lookup_reference
-    attr_accessible :question_reference, :answer_reference, :lookup_reference
+    attr_accessor :question_reference, :answer_reference
+    attr_accessible :question_reference, :answer_reference
   end
 end
 
@@ -228,8 +233,9 @@ module SurveyorRedcapParserAnswerMethods
           :display_order => context[:question].answers.size })
         context[:question].answers << context[:answer] = a
         unless context[:question].reference_identifier.blank? or aref.blank? or !context[:answer].valid?
-          context[:lookup] ||= []
-          context[:lookup] << [context[:question].reference_identifier, aref, context[:answer]]
+          context[:answer_references] ||= {}
+          context[:answer_references][context[:question].reference_identifier] ||= {}
+          context[:answer_references][context[:question].reference_identifier][aref] = context[:answer]
         end
         Surveyor::RedcapParser.rake_trace "#{context[:answer].errors.full_messages}, #{context[:answer].inspect}" unless context[:answer].valid?
         Surveyor::RedcapParser.rake_trace "answer_#{context[:answer].reference_identifier} "


### PR DESCRIPTION
Fix for redcap_parser.rb where dependency conditions with questiona and answer references are not correctly parsed.  The question is not associated when persisted.
