### PR TITLE
make bundler source https because :rubygems uses HTTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://www.rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
The later versions of bundler are deprecating using `source :rubygems` in favor of `source 'https://www.rubygems.org'` because HTTP request is insecure.

It might be a breaking change on machines without OpenSSL or outdated SSL certificates.

Also, bundler might not plan to make :rubygems automatically source to https until Bundler 2.0 (and even then, some people are deprecating the use of magical symbol vs a clear URL).

See https://github.com/carlhuda/bundler/issues/2406
