### PR TITLE
Small fix to get show.html.haml working

### DIFF
--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -1,6 +1,6 @@
 - renderer = g.renderer
 - unless g.display_type == "hidden"
-  = f.inputs "#{next_question_number(g)}#{g.text_for(@render_context, I18n.locale)}", :id => "g_#{g.id}", :class => "g_#{renderer} #{g.css_class(@response_set)}" do
+  = f.inputs "#{next_question_number(g)}#{g.q_text_for(@render_context, I18n.locale)}", :id => "g_#{g.id}", :class => "g_#{renderer} #{g.css_class(@response_set)}" do
     %li.help= g.help_text_for(@render_context, I18n.locale)
     - case renderer
       - when :grid

--- a/lib/surveyor/helpers/surveyor_helper_methods.rb
+++ b/lib/surveyor/helpers/surveyor_helper_methods.rb
@@ -61,6 +61,11 @@ module Surveyor
         "<span class='qnum'>#{@n += 1}) </span>"
       end
 
+      # Answers
+      def a_text(a, context=nil, locale=nil)
+        a.text_for(context, locale)
+      end
+
       # Responses
       def rc_to_attr(type_sym)
         case type_sym.to_s

--- a/lib/surveyor/models/question_group_methods.rb
+++ b/lib/surveyor/models/question_group_methods.rb
@@ -43,7 +43,11 @@ module Surveyor
         [(dependent? ? "g_dependent" : nil), (triggered?(response_set) ? nil : "g_hidden"), custom_class].compact.join(" ")
       end
 
-      def text_for(context = nil, locale = nil)
+      def text_for(_, context = nil, locale = nil)
+        return "" if display_type == "hidden_label"
+        in_context(translation(locale)[:text], context)
+      end
+      def q_text_for(context = nil, locale = nil)
         return "" if display_type == "hidden_label"
         in_context(translation(locale)[:text], context)
       end


### PR DESCRIPTION
This is intended to fix #438. There were two calls to `q.text_for` through the `q_text` helper, one with an arity of two and another with an arity of three. I solved this by separating them into two methods of different names.

It also includes a missing `a_text(a)` helper method.
