### PR TITLE
Conservatively allow Haml 4.x. #434.

### DIFF
--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -18,7 +18,9 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('rails', '~> 3.0')
-  s.add_dependency('haml', '~> 3.1.3')
+  # '< 5.0' is to be conservative; once 5.0 comes out we should test with it and
+  # allow it if it works.
+  s.add_dependency('haml', '>= 3.1.3', '< 5.0')
   s.add_dependency('sass')
   s.add_dependency('fastercsv', '~> 1.5.4')
   s.add_dependency('formtastic', '~> 2.1.0')


### PR DESCRIPTION
`stacktests` (all) passes with Haml 4.0.1, so it seems to be safe to allow it. This commit allows Haml 4.x along with 3.1.x (there is no Haml 3.2, etc.) but not 5.0+. Haml has switched to semver with the 4.0 line, so allowing 4.x should be safe.

This addresses issue #434.
