### PR TITLE
Modified question_group_methods and added tests

### DIFF
--- a/app/views/partials/_question_group.html.haml
+++ b/app/views/partials/_question_group.html.haml
@@ -1,6 +1,6 @@
 - renderer = g.renderer
 - unless g.display_type == "hidden"
-  = f.inputs "#{next_question_number(g)}#{g.text_for(@render_context, I18n.locale)}", :id => "g_#{g.id}", :class => "g_#{renderer} #{g.css_class(@response_set)}" do
+  = f.inputs "#{next_question_number(g)}#{g.text_for(nil, @render_context, I18n.locale)}", :id => "g_#{g.id}", :class => "g_#{renderer} #{g.css_class(@response_set)}" do
     %li.help= g.help_text_for(@render_context, I18n.locale)
     - case renderer
       - when :grid

--- a/app/views/surveyor/show.html.haml
+++ b/app/views/surveyor/show.html.haml
@@ -41,7 +41,7 @@
                               %tr
                                 %th &nbsp;
                                 - ten_questions.first.answers.each do |a|
-                                  %th= a_text(a)
+                                  %th= a.text_for(nil, @render_context, I18n.locale) 
                                 %th &nbsp;
                               - ten_questions.each_with_index do |q, j|
                                 %tr{:id => "q_#{q.id}", :class => "q_#{renderer} #{q.css_class(@response_set)}"}

--- a/lib/surveyor/models/question_group_methods.rb
+++ b/lib/surveyor/models/question_group_methods.rb
@@ -43,18 +43,44 @@ module Surveyor
         [(dependent? ? "g_dependent" : nil), (triggered?(response_set) ? nil : "g_hidden"), custom_class].compact.join(" ")
       end
 
-      def text_for(context = nil, locale = nil)
+      def text_for(position = nil, context = nil, locale = nil)
         return "" if display_type == "hidden_label"
-        in_context(translation(locale)[:text], context)
+        imaged(split(in_context(translation(locale)[:text], context), position))
       end
       def help_text_for(context = nil, locale = nil)
         in_context(translation(locale)[:help_text], context)
       end
+      def split(text, position=nil)
+        case position
+        when :pre
+          text.split("|",2)[0]
+        when :post
+          text.split("|",2)[1]
+        else
+          text
+        end.to_s
+      end
+
+      def part_of_group?
+      end
 
       def translation(locale)
-        {:text => self.text, :help_text => self.help_text}.with_indifferent_access.merge(
-          (self.questions.first.survey_section.survey.translation(locale)[:question_groups] || {})[self.reference_identifier] || {}
+        questions = self.questions
+        text_hash = {:text => self.text,
+                    :help_text => self.help_text}.with_indifferent_access
+        if ! questions.empty?
+          text_hash.merge(
+            (questions.first.survey_section.survey.translation(locale)[:question_groups] || {})[self.reference_identifier] || {}
         )
+        else
+          text_hash
+        end
+      end
+
+      private
+
+      def imaged(text)
+        self.display_type == "image" && !text.blank? ? ActionController::Base.helpers.image_tag(text) : text
       end
     end
   end

--- a/spec/models/question_group_spec.rb
+++ b/spec/models/question_group_spec.rb
@@ -90,4 +90,37 @@ describe QuestionGroup do
       question_group.translation(:de).should == {"text" => "Goodbye", "help_text" => nil}
     end
   end
+  context "for views" do
+    let(:asset_directory){ asset_pipeline_enabled? ? "assets" : "images" }
+    before do
+      ActionController::Base.helpers.config.assets_dir = "public" unless asset_pipeline_enabled?
+    end
+    it "#text_for with #display_type == image" do
+      question_group.text = "rails.png"
+      question_group.display_type = :image
+      question_group.text_for.should == %(<img alt="Rails" src="/#{asset_directory}/rails.png" />)
+    end
+    it "#help_text_for"
+    it "#text_for preserves strings" do
+      question_group.text_for.should == "Describe your family"
+    end
+    it "#text_for(:pre) preserves strings" do
+      question_group.text_for(:pre).should == "Describe your family"
+    end
+    it "#text_for(:post) preserves strings" do
+      question_group.text_for(:post).should == ""
+    end
+    it "#text_for splits strings" do
+      question_group.text = "before|after|extra"
+      question_group.text_for.should == "before|after|extra"
+    end
+    it "#text_for(:pre) splits strings" do
+      question_group.text = "before|after|extra"
+      question_group.text_for(:pre).should == "before"
+    end
+    it "#text_for(:post) splits strings" do
+      question_group.text = "before|after|extra"
+      question_group.text_for(:post).should == "after|extra"
+    end
+  end
 end


### PR DESCRIPTION
This fixes #438.

I am not very familiar with FactoryGirl and how to associate questions to question_group, so I modified the translation method in question_group to simply return the text and help_text hash when the question_group doesn't have any questions.

Commit message: Changed a_text(a) to a.text_for in show.html.haml, replaced text_for in question_group_methods with same method in answer_methods, which takes three parameters, added tests (mostly copying from other tests), and modified translation method to return hash when question_group doesn't have questions. Also copied
split, imaged, and part_of_group? methods.
