### PR TITLE
constrain default order on models #423

### DIFF
--- a/lib/surveyor/models/answer_methods.rb
+++ b/lib/surveyor/models/answer_methods.rb
@@ -10,7 +10,7 @@ module Surveyor
         base.send :has_many, :validations, :dependent => :destroy
 
         # Scopes
-        base.send :default_scope, :order => "display_order ASC"
+        base.send :default_scope, :order => "#{base.quoted_table_name}.display_order ASC"
 
         # Mustache
         base.send :include, MustacheContext

--- a/lib/surveyor/models/question_methods.rb
+++ b/lib/surveyor/models/question_methods.rb
@@ -7,12 +7,12 @@ module Surveyor
         # Associations
         base.send :belongs_to, :survey_section
         base.send :belongs_to, :question_group, :dependent => :destroy
-        base.send :has_many, :answers, :order => "display_order ASC", :dependent => :destroy # it might not always have answers
+        base.send :has_many, :answers, :dependent => :destroy # it might not always have answers
         base.send :has_one, :dependency, :dependent => :destroy
         base.send :belongs_to, :correct_answer, :class_name => "Answer", :dependent => :destroy
 
         # Scopes
-        base.send :default_scope, :order => "display_order ASC"
+        base.send :default_scope, :order => "#{base.quoted_table_name}.display_order ASC"
 
         # Mustache
         base.send :include, MustacheContext

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -7,7 +7,7 @@ module Surveyor
         # Associations
         base.send :belongs_to, :survey
         base.send :belongs_to, :user
-        base.send :has_many, :responses, :order => 'created_at ASC', :dependent => :destroy
+        base.send :has_many, :responses, :order => "#{Response.quoted_table_name}.created_at ASC", :dependent => :destroy
         base.send :accepts_nested_attributes_for, :responses, :allow_destroy => true
 
         @@validations_already_included ||= nil

--- a/lib/surveyor/models/survey_methods.rb
+++ b/lib/surveyor/models/survey_methods.rb
@@ -6,8 +6,8 @@ module Surveyor
     module SurveyMethods
       def self.included(base)
         # Associations
-        base.send :has_many, :sections, :class_name => "SurveySection", :order => 'display_order', :dependent => :destroy
-        base.send :has_many, :sections_with_questions, :include => :questions, :class_name => "SurveySection", :order => 'display_order'
+        base.send :has_many, :sections, :class_name => "SurveySection", :order => "#{SurveySection.quoted_table_name}.display_order", :dependent => :destroy
+        base.send :has_many, :sections_with_questions, :include => :questions, :class_name => "SurveySection", :order => "#{SurveySection.quoted_table_name}.display_order"
         base.send :has_many, :response_sets
         base.send :has_many, :translations, :class_name => "SurveyTranslation"
 

--- a/lib/surveyor/models/survey_section_methods.rb
+++ b/lib/surveyor/models/survey_section_methods.rb
@@ -3,7 +3,7 @@ module Surveyor
     module SurveySectionMethods
       def self.included(base)
         # Associations
-        base.send :has_many, :questions, :order => "display_order ASC", :dependent => :destroy
+        base.send :has_many, :questions, :dependent => :destroy
         base.send :belongs_to, :survey
 
         # Scopes


### PR DESCRIPTION
This attempts to partially resolve issues surrounding default ordering
on models. Order has been removed from associations where the order
has already been specified on the target model. In all other cases the
ordering has been scoped to the table. This should not modify the
order specified to any queries.

This allows cases, etc. to perform joins without
explicitly removing order constraints. Possible performance overheads
associated with unnecessary sorting are still an issue. Also, model
class names have been hardcoded to scope associations. I am not sure
how to get around this.

The goal is to allow cases to use mainline surveyor releases.
