### PR TITLE
display times in rails configured timezone #435

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ namespace :testbed do
   task :migrate do
     chdir('testbed') do
       Bundler.with_clean_env do
-        sh 'bundle exec rails generate surveyor:install'
+        sh 'bundle exec rails generate surveyor:install --timezone=Rome'
         sh 'bundle exec rake db:migrate db:test:prepare'
       end
     end

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,10 @@ task :testbed => 'testbed:rebuild'
 namespace :testbed do
   desc 'Generate a minimal surveyor-using rails app'
   task :generate do
-    sh 'bundle exec rails new testbed --skip-bundle' # don't run bundle install until the Gemfile modifications
+    Tempfile.open('surveyor_Rakefile') do |f|
+      f.write("application \"config.time_zone='Rome'\"");f.flush
+      sh "bundle exec rails new testbed --skip-bundle -m #{f.path}" # don't run bundle install until the Gemfile modifications
+    end
     chdir('testbed') do
       gem_file_contents = File.read('Gemfile')
       gem_file_contents.sub!(/^(gem 'rails'.*)$/, %Q{# \\1\nplugin_root = File.expand_path('../..', __FILE__)\neval(File.read File.join(plugin_root, 'Gemfile.rails_version'))\ngem 'surveyor', :path => plugin_root})
@@ -56,7 +59,7 @@ namespace :testbed do
   task :migrate do
     chdir('testbed') do
       Bundler.with_clean_env do
-        sh 'bundle exec rails generate surveyor:install --timezone=Rome'
+        sh 'bundle exec rails generate surveyor:install'
         sh 'bundle exec rake db:migrate db:test:prepare'
       end
     end

--- a/app/views/partials/_answer.html.haml
+++ b/app/views/partials/_answer.html.haml
@@ -19,7 +19,7 @@
                   :as         => rc_to_as(a.response_class),
                   :label      => a.text_for(:pre, @render_context, I18n.locale).blank? ? false : a.text_for(:pre, @render_context, I18n.locale),
                   :hint       => a.text_for(:post, @render_context, I18n.locale),
-                  :input_html => generate_pick_none_input_html(r.as(a.response_class), a.default_value_for(@render_context, I18n.locale), a.css_class, a.response_class, disabled, a.input_mask, a.input_mask_placeholder)
+                  :input_html => generate_pick_none_input_html(r.to_formatted_s, a.default_value_for(@render_context, I18n.locale), a.css_class, a.response_class, disabled, a.input_mask, a.input_mask_placeholder)
     - else
       = a.text_for(nil, @render_context, I18n.locale)
   %span.help= a.help_text_for(@render_context, I18n.locale) unless g && g.display_type == "grid"

--- a/ci-exec.sh
+++ b/ci-exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-BUNDLER_VERSION=1.1.5
+BUNDLER_VERSION=1.3.1
 GEMSET=surveyor
 
 if [ -z $CI_RUBY ]; then

--- a/lib/assets/javascripts/surveyor/jquery.surveyor.js
+++ b/lib/assets/javascripts/surveyor/jquery.surveyor.js
@@ -35,7 +35,7 @@ jQuery(document).ready(function(){
   jQuery("input[type='text'].datetime").datetimepicker({
     showSecond: true,
     showMillisec: false,
-    timeFormat: 'hh:mm:ss',
+    timeFormat: 'HH:mm:ss',
     dateFormat: 'yy-mm-dd',
     changeMonth: true,
     changeYear: true

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -9,8 +9,6 @@ module Surveyor
     source_root File.expand_path("../templates", __FILE__)
     desc "Generate surveyor README, migrations, assets and sample survey"
     class_option :skip_migrations, :type => :boolean, :desc => "skip migrations, but generate everything else"
-    class_option :timezone,       :type => :string,  :desc => "set the Rails timezone in config/application.rb", :default => ""
-
 
     MIGRATION_ORDER = %w(
       create_surveys
@@ -99,14 +97,5 @@ module Surveyor
     def locales
       directory "config/locales"
     end
-
-    def application_config
-      unless options[:timezone].blank?
-        application do
-          "config.time_zone = '#{options[:timezone]}'"
-        end
-      end
-    end
-
   end
 end

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -9,6 +9,7 @@ module Surveyor
     source_root File.expand_path("../templates", __FILE__)
     desc "Generate surveyor README, migrations, assets and sample survey"
     class_option :skip_migrations, :type => :boolean, :desc => "skip migrations, but generate everything else"
+    class_option :timezone,       :type => :string,  :desc => "set the Rails timezone in config/application.rb", :default => ""
 
 
     MIGRATION_ORDER = %w(
@@ -100,8 +101,10 @@ module Surveyor
     end
 
     def application_config
-      application do
-        "config.time_zone = 'Rome'"
+      unless options[:timezone].blank?
+        application do
+          "config.time_zone = '#{options[:timezone]}'"
+        end
       end
     end
 

--- a/lib/generators/surveyor/install_generator.rb
+++ b/lib/generators/surveyor/install_generator.rb
@@ -10,6 +10,7 @@ module Surveyor
     desc "Generate surveyor README, migrations, assets and sample survey"
     class_option :skip_migrations, :type => :boolean, :desc => "skip migrations, but generate everything else"
 
+
     MIGRATION_ORDER = %w(
       create_surveys
       create_survey_sections
@@ -97,5 +98,12 @@ module Surveyor
     def locales
       directory "config/locales"
     end
+
+    def application_config
+      application do
+        "config.time_zone = 'Rome'"
+      end
+    end
+
   end
 end

--- a/lib/surveyor/helpers/surveyor_helper_methods.rb
+++ b/lib/surveyor/helpers/surveyor_helper_methods.rb
@@ -79,7 +79,7 @@ module Surveyor
       def generate_pick_none_input_html(value, default_value, css_class, response_class, disabled, input_mask, input_mask_placeholder)
         html = {}
         html[:class] = [response_class,css_class].reject{ |c| c.blank? }
-        html[:value] = default_value if value.blank?
+        html[:value] = value.blank? ? default_value : value
         html[:disabled] = disabled unless disabled.blank?
         if input_mask
           html[:'data-input-mask'] = input_mask

--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -75,7 +75,23 @@ module Surveyor
       end
 
       def datetime_format
-        '%Y-%m-%d %H:%M'
+        '%Y-%m-%d %H:%M:%S'
+      end
+
+      def to_formatted_s
+        return "" if answer.nil? || answer.response_class.nil?
+        return case t = answer.response_class.to_sym
+               when :string, :text, :integer, :float
+                 send("#{t}_value".to_sym).to_s
+               when :date
+                 date_value
+               when :time
+                 time_value
+               when :datetime
+                 read_attribute(:datetime_value).strftime(datetime_format)
+               else
+                 to_s
+               end
       end
 
       def to_s # used in dependency_explanation_helper
@@ -96,7 +112,7 @@ module Surveyor
         }
 
         found = formats[answer.response_class]
-        found ?  datetime_value.try(:strftime, found) : as(answer.response_class)
+        found ? datetime_value.try{|d| d.utc.strftime(found)} : as(answer.response_class)
       end
     end
   end

--- a/spec/models/response_set_spec.rb
+++ b/spec/models/response_set_spec.rb
@@ -132,11 +132,13 @@ describe ResponseSet do
       end
 
       [
-        ['string_value',   'foo',           '', 'foo'],
-        ['datetime_value', '2010-10-01',    '', Date.new(2010, 10, 1)],
-        ['integer_value',  '9',             '', 9],
-        ['float_value',    '4.0',           '', 4.0],
-        ['text_value',     'more than foo', '', 'more than foo']
+        ['string_value',   'foo',              '', 'foo'],
+        ['datetime_value', '2010-10-01 17:15', '', Time.zone.parse('2010-10-1 17:15')],
+        ['date_value',     '2010-10-01',       '', '2010-10-01'],
+        ['time_value',     '17:15',            '', '17:15'],
+        ['integer_value',  '9',                '', 9],
+        ['float_value',    '4.0',              '', 4.0],
+        ['text_value',     'more than foo',    '', 'more than foo']
       ].each do |value_type, set_value, blank_value, expected_value|
         describe "plus #{value_type}" do
           it 'saves the value' do


### PR DESCRIPTION
testbed now has a (non-utc) timezone by default so that the model data
is different from the database and this functionality is covered by
rspec, cucumber.

fixes bug in datetime, where afternoon times are recording as
morning. This was already implemented in cases, see
https://code.bioinformatics.northwestern.edu/issues/issues/show/3415
