### PR TITLE
Correct nil handling in date_value= and time_value=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ History for Surveyor
 1.4.1
 -----
 
+### Fixes
+
+- Handle `nil` in `ResponseMethods#date_value=` and `ResponseMethods#time_value`.
+  (#450)
 
 1.4.0
 -----

--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -55,7 +55,12 @@ module Surveyor
       end
 
       def time_value=(val)
-        self.datetime_value = Time.zone.parse("#{Date.today.to_s} #{val}") ? Time.zone.parse("#{Date.today.to_s} #{val}").to_datetime : nil
+        self.datetime_value =
+          if val && time = Time.zone.parse("#{Date.today.to_s} #{val}")
+            time.to_datetime
+          else
+            nil
+          end
       end
 
       def date_value
@@ -63,7 +68,12 @@ module Surveyor
       end
 
       def date_value=(val)
-        self.datetime_value = Time.zone.parse(val) ? Time.zone.parse(val).to_datetime : nil
+        self.datetime_value =
+          if val && time = Time.zone.parse(val)
+            time.to_datetime
+          else
+            nil
+          end
       end
 
       def time_format

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -174,3 +174,33 @@ describe Response, '#json_value' do
     end
   end
 end
+
+describe Response, 'value methods' do
+  let(:response) { Response.new }
+
+  describe '#date_value=' do
+    it 'accepts a parseable date string' do
+      response.date_value = '2010-01-15'
+      response.datetime_value.strftime('%Y %m %d').should == '2010 01 15'
+    end
+
+    it 'clears when given nil' do
+      response.datetime_value = Time.new
+      response.date_value = nil
+      response.datetime_value.should be_nil
+    end
+  end
+
+  describe 'time_value=' do
+    it 'accepts a parseable time string' do
+      response.time_value = '11:30'
+      response.datetime_value.strftime('%H %M %S').should == '11 30 00'
+    end
+
+    it 'clears when given nil' do
+      response.datetime_value = Time.new
+      response.time_value = nil
+      response.datetime_value.should be_nil
+    end
+  end
+end


### PR DESCRIPTION
Without this change:
- `ResponseMethods#date_value=` fails with "can't convert nil into String" when given `nil`
- `ResponseMethods#time_value=` accepts a `nil`, but turns it into the time "midnight" instead of `nil`
