### PR TITLE
ResponseMethods#to_formatted_s incorrectly assumes non-nil datetime_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ History for Surveyor
 
 - Handle `nil` in `ResponseMethods#date_value=` and `ResponseMethods#time_value`.
   (#450)
+- Handle `nil` datetime values in `ResponseMethods#to_formatted_s`.  (#459)
 
 1.4.0
 -----

--- a/lib/surveyor/models/response_methods.rb
+++ b/lib/surveyor/models/response_methods.rb
@@ -51,7 +51,7 @@ module Surveyor
       end
 
       def time_value
-        read_attribute(:datetime_value).strftime( time_format ) unless read_attribute(:datetime_value).blank?
+        datetime_value.try(:strftime, time_format)
       end
 
       def time_value=(val)
@@ -64,7 +64,7 @@ module Surveyor
       end
 
       def date_value
-        read_attribute(:datetime_value).strftime( date_format ) unless read_attribute(:datetime_value).blank?
+        datetime_value.try(:strftime, date_format)
       end
 
       def date_value=(val)
@@ -74,6 +74,10 @@ module Surveyor
           else
             nil
           end
+      end
+
+      def datetime_value
+        read_attribute(:datetime_value)
       end
 
       def time_format
@@ -98,7 +102,7 @@ module Surveyor
                when :time
                  time_value
                when :datetime
-                 read_attribute(:datetime_value).strftime(datetime_format)
+                 datetime_value.try(:strftime, datetime_format) || ''
                else
                  to_s
                end

--- a/spec/models/response_spec.rb
+++ b/spec/models/response_spec.rb
@@ -128,6 +128,18 @@ describe Response, "applicable_attributes" do
   end
 end
 
+describe Response, '#to_formatted_s' do
+  context "when datetime" do
+    let(:r) { Response.new(:answer => Answer.new(:response_class => 'datetime')) }
+
+    it 'returns "" when nil' do
+      r.datetime_value = nil
+
+      r.to_formatted_s.should == ""
+    end
+  end
+end
+
 describe Response, '#json_value' do
   context "when integer" do
     let(:r) {Response.new(:integer_value => 2, :answer => Answer.new(:response_class => 'integer'))}


### PR DESCRIPTION
See https://github.com/NUBIC/surveyor/blob/master/lib/surveyor/models/response_methods.rb#L101.

Also see https://github.com/NUBIC/surveyor/blob/v1.4.0/lib/surveyor/models/response_methods.rb#L91, which [affects NCS applications](https://code.bioinformatics.northwestern.edu/issues/issues/show/4389).
