### PR TITLE
Fix false positive for Question#triggered?

### DIFF
--- a/lib/surveyor/models/question_methods.rb
+++ b/lib/surveyor/models/question_methods.rb
@@ -63,7 +63,13 @@ module Surveyor
         self.dependency != nil
       end
       def triggered?(response_set)
-        dependent? ? self.dependency.is_met?(response_set) : true
+        if dependent?
+          dependency.is_met?(response_set)
+        elsif question_group.try(:dependent?)
+          question_group.dependency.is_met?(response_set)
+        else
+          true
+        end
       end
       def css_class(response_set)
         [(dependent? ? "q_dependent" : nil), (triggered?(response_set) ? nil : "q_hidden"), custom_class].compact.join(" ")

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -112,6 +112,7 @@ module Surveyor
           false
         else
           self.responses.detect{|r| r.question_id == question.id}.nil?
+        end
       end
       def is_group_unanswered?(group)
         group.questions.any?{|question| is_unanswered?(question)}

--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -108,7 +108,10 @@ module Surveyor
         %w(label image).include?(question.display_type) or !is_unanswered?(question)
       end
       def is_unanswered?(question)
-        self.responses.detect{|r| r.question_id == question.id}.nil?
+        if question.display_type == 'label'
+          false
+        else
+          self.responses.detect{|r| r.question_id == question.id}.nil?
       end
       def is_group_unanswered?(group)
         group.questions.any?{|question| is_unanswered?(question)}


### PR DESCRIPTION
I'm working on enforcing mandatory questions, and I noticed that questions without explicit dependencies inside of question groups with dependencies were erroneously reporting themselves to be triggered, which prevented a user from moving on in the survey.

This issue probably needs to be addressed inside `ResponseSet#progress_hash` as well.
