### PR TITLE
Fixes #482 Rails 4.1 breaks models/response_set_spec

### DIFF
--- a/lib/surveyor/models/response_set_methods.rb
+++ b/lib/surveyor/models/response_set_methods.rb
@@ -81,7 +81,7 @@ module Surveyor
       end
       def correctness_hash
         { :questions => Survey.where(id: self.survey_id).includes(sections: :questions).first.sections.map(&:questions).flatten.compact.size,
-          :responses => responses.compact.size,
+          :responses => responses.to_a.compact.size,
           :correct => responses.find_all(&:correct?).compact.size
         }
       end


### PR DESCRIPTION
ActiveRecord relations no longer support the compact method
directly.  Use to_a first.
