### PR TITLE
Switching to mysql for tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ namespace :testbed do
     Tempfile.open('surveyor_Rakefile') do |f|
       f.write("application \"config.time_zone='Rome'\"\n")
       f.flush
-      sh "bundle exec rails new testbed --skip-bundle -m #{f.path}" # don't run bundle install until the Gemfile modifications
+      sh "bundle exec rails new testbed -d mysql --skip-bundle -m #{f.path}" # don't run bundle install until the Gemfile modifications
     end
     chdir('testbed') do
       gem_file_contents = File.read('Gemfile')
@@ -41,7 +41,7 @@ namespace :testbed do
     chdir('testbed') do
       Bundler.with_clean_env do
         sh 'bundle exec rails generate surveyor:install'
-        sh 'bundle exec rake db:migrate db:test:prepare'
+        sh 'bundle exec rake db:migrate:reset db:test:prepare'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   # https://github.com/rspec/rspec-core/issues/456
   config.verbose_retry       = true # show retry status in spec process
   retry_count                = ENV['RSPEC_RETRY_COUNT']
-  config.default_retry_count = retry_count.try(:to_i) || 1
+  config.default_retry_count = retry_count.try(:to_i) || 5
   puts "RSpec retry count is #{config.default_retry_count}"
 
   ## Database Cleaner

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,5 +1,5 @@
 module WaitForAjax
-  def wait_for_ajax(wait_time = 1)
+  def wait_for_ajax(wait_time = 3)
     Timeout.timeout(wait_time) do
       loop until finished_all_ajax_requests?
     end

--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('yard')
   s.add_development_dependency('rake')
-  s.add_development_dependency('sqlite3')
+  s.add_development_dependency('mysql2')
   s.add_development_dependency('bundler', '~> 1.6')
   s.add_development_dependency('rspec-rails', '~> 2.14.2')
   s.add_development_dependency('capybara', '~> 2.2.1')

--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('yard')
   s.add_development_dependency('rake')
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('bundler', '~> 1.6.1')
+  s.add_development_dependency('bundler', '~> 1.6')
   s.add_development_dependency('rspec-rails', '~> 2.14.2')
   s.add_development_dependency('capybara', '~> 2.2.1')
   s.add_development_dependency('launchy', '~> 2.4.2')


### PR DESCRIPTION
Currently, all the specs should pass (with ajax tests being somewhat unstable), but a number of specs are failing on Travis with the following error:

```
 SQLite3::BusyException: database is locked:
```

This can be observed in https://travis-ci.org/NUBIC/surveyor/jobs/24947822 and other recent builds.

Switching to mysql (or any other "real" database) could fix that with the added benefit of testing against a more realistic environment.
