### PR TITLE
Respect display order for sections and enforce mandatory questions

### DIFF
--- a/app/views/surveyor/edit.html.haml
+++ b/app/views/surveyor/edit.html.haml
@@ -6,6 +6,7 @@
   = semantic_form_for(@response_set, :as => :r, :url => surveyor.update_my_survey_path, :html => {:method => :put, :id => "survey_form", :class => @survey.custom_class}) do |f|
 
     = hidden_field_tag :surveyor_javascript_enabled, false
+    = hidden_field_tag :section, @section.id
 
     = render 'partials/section_menu' # unless @sections.size < 3
     .survey_title= @survey.translation(I18n.locale)[:title]

--- a/lib/generators/surveyor/templates/config/locales/surveyor_en.yml
+++ b/lib/generators/surveyor/templates/config/locales/surveyor_en.yml
@@ -10,6 +10,7 @@ en:
     unable_to_find_your_responses: "Unable to find your responses to the survey"
     unable_to_update_survey: "Unable to update survey"
     unable_to_find_that_survey: "Unable to find that survey"
+    incomplete_mandatory_questions: "Please complete all mandatory questions"
     survey_started_success: "Survey started successfully"
     click_here_to_finish: "Click here to finish"
     previous_section: "&laquo; Previous section"

--- a/lib/surveyor/helpers/surveyor_helper_methods.rb
+++ b/lib/surveyor/helpers/surveyor_helper_methods.rb
@@ -24,14 +24,10 @@ module Surveyor
         submit_tag(section.translation(I18n.locale)[:title], :name => "section[#{section.id}]")
       end
       def previous_section
-        # use copy in memory instead of making extra db calls
-        prev_index = [(@sections.index(@section) || 0) - 1, 0].max
-        submit_tag(t('surveyor.previous_section').html_safe, :name => "section[#{@sections[prev_index].id}]") unless @sections[0] == @section
+        submit_tag(t('surveyor.previous_section').html_safe, :name => "previous") if @section.previous
       end
       def next_section
-        # use copy in memory instead of making extra db calls
-        next_index = [(@sections.index(@section) || @sections.count) + 1, @sections.count].min
-        @sections.last == @section ? submit_tag(t('surveyor.click_here_to_finish').html_safe, :name => "finish") : submit_tag(t('surveyor.next_section').html_safe, :name => "section[#{@sections[next_index].id}]")
+        @section.next ? submit_tag(t('surveyor.next_section').html_safe, :name => "next") : submit_tag(t('surveyor.click_here_to_finish').html_safe, :name => "finish")
       end
 
       # Questions

--- a/lib/surveyor/models/survey_section_methods.rb
+++ b/lib/surveyor/models/survey_section_methods.rb
@@ -5,6 +5,8 @@ module Surveyor
       include ActiveModel::Validations
       include ActiveModel::ForbiddenAttributesProtection
 
+      default_scope order('display_order ASC')
+
       included do
         # Associations
         has_many :questions, :dependent => :destroy
@@ -43,6 +45,15 @@ module Surveyor
           (self.survey.translation(locale)[:survey_sections] || {})[self.reference_identifier] || {}
         )
       end
+
+      def next
+        SurveySection.where("survey_id = (?) AND display_order > (?)", survey_id, display_order).first
+      end
+    
+      def previous
+        SurveySection.where("survey_id = (?) AND display_order < (?)", survey_id, display_order).last
+      end
+
     end
   end
 end


### PR DESCRIPTION
I modified the previous and next button helpers to respect the display order property of sections and allow server-side control of survey flow. I also wrote a new method to check whether all mandatory questions in a given section have been answered. This works correctly for labels, optional questions, etc. The last commit uses this method to add a configurable option which can prevent the user from moving to the next section before completing all mandatory questions in the current section.
