### PR TITLE
restrict the required module version to run in ruby 2.3

### DIFF
--- a/surveyor.gemspec
+++ b/surveyor.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |s|
   s.add_dependency('rabl', '~> 0.6')
 
   s.add_development_dependency('yard')
-  s.add_development_dependency('rake')
+  s.add_development_dependency('rake', '< 11.0')
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('bundler', '~> 1.6.1')
+  s.add_development_dependency('bundler')
   s.add_development_dependency('rspec-rails', '~> 2.14.2')
   s.add_development_dependency('capybara', '~> 2.2.1')
   s.add_development_dependency('launchy', '~> 2.4.2')
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('json_spec', '~> 1.1.1')
   s.add_development_dependency('factory_girl', '~> 4.4.0')
   s.add_development_dependency('database_cleaner', '~> 1.2.0')
-  s.add_development_dependency('rspec-retry')
+  s.add_development_dependency('rspec-retry', '~> 0.4.4')
+  s.add_development_dependency('test-unit')
 end
 


### PR DESCRIPTION
As time goes by, these libraries no longer works with the latest version... therefore, restriction needs to be set upon the library for development purpose.